### PR TITLE
Yarn compliance

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ import path from 'path';
 /**
  * The name of this project. Used to exclude this repo as a lintable project.
  */
-export const THIS_PROJECT_NAME = 'module-lint';
+export const THIS_PROJECT_NAME = '@metamask/module-lint';
 
 /**
  * The root directory of this project.

--- a/src/repository-filesystem.ts
+++ b/src/repository-filesystem.ts
@@ -44,6 +44,18 @@ export class RepositoryFilesystem {
   }
 
   /**
+   * Reads a file within the repository.
+   *
+   * @param filePath - The path to the file within the context of the repository
+   * (so, minus its directory).
+   * @returns The JSON object of the file.
+   */
+  async readJsonFile(filePath: string): Promise<any> {
+    const content = await this.readFile(filePath);
+    return JSON.parse(content);
+  }
+
+  /**
    * Retrieves stats for the given file or directory.
    *
    * @param entryPath - The path to the file or directory within the context of

--- a/src/rules/comply-yarn.ts
+++ b/src/rules/comply-yarn.ts
@@ -13,6 +13,7 @@ export default buildRule({
     await complyYarnPluginAllowScripts(project, template, failures);
     await complyYarnPluginConstraints(project, template, failures);
     await complyReleasesYarnCjs(project, template, failures);
+    await complyYarnRC(project, template, failures);
 
     return failures.length === 0 ? pass() : fail(failures);
   },
@@ -132,6 +133,33 @@ async function complyReleasesYarnCjs(
     }
   } else {
     failures.push({ message: `yarn-${yarnVersion}.cjs doesn not exist` });
+  }
+}
+
+/**
+ * Verifies whether .yarnrc.yml file exist and matches the same in module template.
+ *
+ * @param project - The project repository to execute the rules against.
+ * @param template - The template repository to compare the project to.
+ * @param failures - The array of failures from executing the rule.
+ */
+async function complyYarnRC(
+  project: MetaMaskRepository,
+  template: MetaMaskRepository,
+  failures: RuleExecutionFailure[],
+) {
+  const entryPath = '.yarnrc.yml';
+  const projectFile = await project.fs.readFile(entryPath);
+  const templateFile = await template.fs.readFile(entryPath);
+
+  if (projectFile) {
+    if (projectFile !== templateFile) {
+      failures.push({
+        message: '.yarnrc.yml does not match the same in module template',
+      });
+    }
+  } else {
+    failures.push({ message: '.yarnrc.yml doesn not exist' });
   }
 }
 

--- a/src/rules/comply-yarn.ts
+++ b/src/rules/comply-yarn.ts
@@ -11,6 +11,7 @@ export default buildRule({
     const failures: RuleExecutionFailure[] = [];
     await complyYarnPackageManager(project, template, failures);
     await complyYarnPluginAllowScripts(project, template, failures);
+    await complyYarnPluginConstraints(project, template, failures);
 
     return failures.length === 0 ? pass() : fail(failures);
   },
@@ -74,5 +75,33 @@ async function complyYarnPluginAllowScripts(
     }
   } else {
     failures.push({ message: 'plugin-allow-scripts.cjs doesn not exist' });
+  }
+}
+
+/**
+ * Verifies whether plugin-constraints.cjs file exist and matches the same in module template.
+ *
+ * @param project - The project repository to execute the rules against.
+ * @param template - The template repository to compare the project to.
+ * @param failures - The array of failures from executing the rule.
+ */
+async function complyYarnPluginConstraints(
+  project: MetaMaskRepository,
+  template: MetaMaskRepository,
+  failures: RuleExecutionFailure[],
+) {
+  const entryPath = '.yarn/plugins/@yarnpkg/plugin-constraints.cjs';
+  const projectFile = await project.fs.readFile(entryPath);
+  const templateFile = await template.fs.readFile(entryPath);
+
+  if (projectFile) {
+    if (projectFile !== templateFile) {
+      failures.push({
+        message:
+          'plugin-constraints.cjs does not match the same in module template',
+      });
+    }
+  } else {
+    failures.push({ message: 'plugin-constraints.cjs doesn not exist' });
   }
 }

--- a/src/rules/comply-yarn.ts
+++ b/src/rules/comply-yarn.ts
@@ -10,6 +10,7 @@ export default buildRule({
   execute: async ({ project, template, pass, fail }) => {
     const failures: RuleExecutionFailure[] = [];
     await complyYarnPackageManager(project, template, failures);
+    await complyYarnPluginAllowScripts(project, template, failures);
 
     return failures.length === 0 ? pass() : fail(failures);
   },
@@ -45,5 +46,33 @@ async function complyYarnPackageManager(
     }
   } else {
     failures.push({ message: 'yarn doesn not exist' });
+  }
+}
+
+/**
+ * Verifies whether plugin-allow-scripts.cjs file exist and matches the same in module template.
+ *
+ * @param project - The project repository to execute the rules against.
+ * @param template - The template repository to compare the project to.
+ * @param failures - The array of failures from executing the rule.
+ */
+async function complyYarnPluginAllowScripts(
+  project: MetaMaskRepository,
+  template: MetaMaskRepository,
+  failures: RuleExecutionFailure[],
+) {
+  const entryPath = '.yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs';
+  const projectFile = await project.fs.readFile(entryPath);
+  const templateFile = await template.fs.readFile(entryPath);
+
+  if (projectFile) {
+    if (projectFile !== templateFile) {
+      failures.push({
+        message:
+          'plugin-allow-scripts.cjs does not match the same in module template',
+      });
+    }
+  } else {
+    failures.push({ message: 'plugin-allow-scripts.cjs doesn not exist' });
   }
 }

--- a/src/rules/comply-yarn.ts
+++ b/src/rules/comply-yarn.ts
@@ -1,0 +1,49 @@
+import { buildRule } from './helpers';
+import { RuleName } from './types';
+import type { MetaMaskRepository } from '../establish-metamask-repository';
+import type { RuleExecutionFailure } from '../execute-rules';
+
+export default buildRule({
+  name: RuleName.ComplyYarn,
+  description: 'Does the `yarn` comply?',
+  dependencies: [],
+  execute: async ({ project, template, pass, fail }) => {
+    const failures: RuleExecutionFailure[] = [];
+    await complyYarnPackageManager(project, template, failures);
+
+    return failures.length === 0 ? pass() : fail(failures);
+  },
+});
+
+/**
+ * Verifies whether packageManager field in package.json exist and matches the same in module template.
+ *
+ * @param project - The project repository to execute the rules against.
+ * @param template - The template repository to compare the project to.
+ * @param failures - The array of failures from executing the rule.
+ */
+async function complyYarnPackageManager(
+  project: MetaMaskRepository,
+  template: MetaMaskRepository,
+  failures: RuleExecutionFailure[],
+) {
+  const entryPath = 'package.json';
+
+  // packageManager from project repo
+  const packageJson = await project.fs.readJsonFile(entryPath);
+  const packageManager: string = packageJson?.packageManager;
+
+  // packageManager from template-module repo
+  const templatePackageJson = await template.fs.readJsonFile(entryPath);
+  const templatePackageManager: string = templatePackageJson?.packageManager;
+
+  if (packageManager?.includes('yarn')) {
+    if (packageManager !== templatePackageManager) {
+      failures.push({
+        message: `\`${packageManager}\` does not match module template \`${templatePackageManager}\``,
+      });
+    }
+  } else {
+    failures.push({ message: 'yarn doesn not exist' });
+  }
+}

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,3 +1,4 @@
+import requirePackageJson from './require-package-json';
 import requireSourceDirectory from './require-source-directory';
 
-export const rules = [requireSourceDirectory] as const;
+export const rules = [requireSourceDirectory, requirePackageJson] as const;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,4 +1,9 @@
 import requirePackageJson from './require-package-json';
+import requireReadme from './require-readme';
 import requireSourceDirectory from './require-source-directory';
 
-export const rules = [requireSourceDirectory, requirePackageJson] as const;
+export const rules = [
+  requireSourceDirectory,
+  requirePackageJson,
+  requireReadme,
+] as const;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,3 +1,4 @@
+import complyYarn from './comply-yarn';
 import requirePackageJson from './require-package-json';
 import requireReadme from './require-readme';
 import requireSourceDirectory from './require-source-directory';
@@ -6,4 +7,5 @@ export const rules = [
   requireSourceDirectory,
   requirePackageJson,
   requireReadme,
+  complyYarn,
 ] as const;

--- a/src/rules/require-package-json.ts
+++ b/src/rules/require-package-json.ts
@@ -1,0 +1,19 @@
+import { buildRule } from './helpers';
+import { RuleName } from './types';
+
+export default buildRule({
+  name: RuleName.RequirePackageJson,
+  description: 'Does the `package.json` exist?',
+  dependencies: [],
+  execute: async ({ project, pass, fail }) => {
+    const entryPath = 'package.json';
+    const stats = await project.fs.getEntryStats(entryPath);
+    const passed = stats?.isFile();
+    const message = stats
+      ? `\`${entryPath}\` is not a file when it should be.`
+      : `\`${entryPath}\` exists in the module template, but not in this repo.`;
+    const failures = [{ message }];
+
+    return passed ? pass() : fail(failures);
+  },
+});

--- a/src/rules/require-readme.ts
+++ b/src/rules/require-readme.ts
@@ -1,0 +1,21 @@
+import { buildRule } from './helpers';
+import { RuleName } from './types';
+
+export default buildRule({
+  name: RuleName.RequireSourceDirectory,
+  description: 'Does the `README.md` file exist?',
+  dependencies: [],
+  execute: async ({ project, pass, fail }) => {
+    const entryPath = 'README.md';
+    const stats = await project.fs.getEntryStats(entryPath);
+    const passed = stats?.isFile();
+
+    return passed
+      ? pass()
+      : fail([
+          {
+            message: `\`${entryPath}\` exists in the module template, but not in this repo.`,
+          },
+        ]);
+  },
+});

--- a/src/rules/require-readme.ts
+++ b/src/rules/require-readme.ts
@@ -2,7 +2,7 @@ import { buildRule } from './helpers';
 import { RuleName } from './types';
 
 export default buildRule({
-  name: RuleName.RequireSourceDirectory,
+  name: RuleName.RequireREADME,
   description: 'Does the `README.md` file exist?',
   dependencies: [],
   execute: async ({ project, pass, fail }) => {

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -5,4 +5,5 @@ export enum RuleName {
   RequireSourceDirectory = 'require-source-directory',
   RequirePackageJson = 'require-package-json',
   RequireREADME = 'require-readme',
+  ComplyYarn = 'comply-yarn',
 }

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -4,4 +4,5 @@
 export enum RuleName {
   RequireSourceDirectory = 'require-source-directory',
   RequirePackageJson = 'require-package-json',
+  RequireREADME = 'require-readme',
 }

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -3,4 +3,5 @@
  */
 export enum RuleName {
   RequireSourceDirectory = 'require-source-directory',
+  RequirePackageJson = 'require-package-json',
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
Since the module template uses Yarn v3, we want all projects to conform to the same thing. So, minimally, for this ticket, we want this tool to be able to look a project and verify whether it is using the same version of Yarn as is specified in the module template.

There are several ways to check that the Yarn version conforms, though. If this is the case for a project, then these things will be true:

- The packageManager field in package.json should exist
- The value of the packageManager field should match the same value as the module template
- .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs should exist, and its contents should match what's in the module template
- .yarn/plugins/@yarnpkg/plugin-constraints.cjs should exist, and its contents should match what's in the module template
- .yarn/releases/yarn-3.2.1.cjs should exist, and its contents should match what's in the module template
- The .yarnrc.yml file should exist, and the contents of this file should match the same file in the module template
- The README should include a line - Install [Yarn v3](https://yarnpkg.com/getting-started/install)

## References

- Closes #23 
- Closes #11 