### PR TITLE
Add rule execution code

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "@metamask/utils": "^8.2.0",
+    "dependency-graph": "^0.11.0",
     "execa": "^5.1.1"
   },
   "devDependencies": {

--- a/src/build-rule-tree.test.ts
+++ b/src/build-rule-tree.test.ts
@@ -1,0 +1,136 @@
+import * as dependencyGraphModule from 'dependency-graph';
+
+import { buildRuleTree } from './build-rule-tree';
+import type { Rule } from './execute-rules';
+
+jest.mock('dependency-graph', () => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    ...jest.requireActual('dependency-graph'),
+  };
+});
+
+describe('buildRuleTree', () => {
+  it('builds a nested data structure that starts with the rules that have no dependencies and navigates through their dependents recursively', () => {
+    const rule1: Rule = {
+      name: 'rule-1',
+      description: 'Description for rule 1',
+      dependencies: ['rule-2'],
+      execute: async () => {
+        return {
+          passed: true,
+        };
+      },
+    };
+    const rule2: Rule = {
+      name: 'rule-2',
+      description: 'Description for rule 2',
+      dependencies: ['rule-3'],
+      execute: async () => {
+        return {
+          passed: true,
+        };
+      },
+    };
+    const rule3: Rule = {
+      name: 'rule-3',
+      description: 'Description for rule 3',
+      dependencies: [],
+      execute: async () => {
+        return {
+          passed: true,
+        };
+      },
+    };
+    const rules = [rule1, rule2, rule3];
+
+    const ruleTree = buildRuleTree(rules);
+
+    expect(ruleTree).toStrictEqual({
+      children: [
+        {
+          rule: rule3,
+          children: [
+            {
+              rule: rule2,
+              children: [
+                {
+                  rule: rule1,
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('reinterprets a dependency cycle error from dep-graph if given a set of rules where a dependency cycle is present', () => {
+    const rule1: Rule = {
+      name: 'rule-1',
+      description: 'Description for rule 1',
+      dependencies: ['rule-2'],
+      execute: async () => {
+        return {
+          passed: false,
+          failures: [{ message: 'Oops' }],
+        };
+      },
+    };
+    const rule2: Rule = {
+      name: 'rule-2',
+      description: 'Description for rule 2',
+      dependencies: ['rule-3'],
+      execute: async () => {
+        return {
+          passed: true,
+        };
+      },
+    };
+    const rule3: Rule = {
+      name: 'rule-3',
+      description: 'Description for rule 3',
+      dependencies: ['rule-1'],
+      execute: async () => {
+        return {
+          passed: true,
+        };
+      },
+    };
+    const rules = [rule1, rule2, rule3];
+
+    expect(() => buildRuleTree(rules)).toThrow(
+      new Error(
+        `
+Could not build rule tree as some rules depend on each other circularly:
+
+- Rule "rule-1" depends on...
+  - Rule "rule-2", which depends on...
+    - Rule "rule-3", which depends on...
+      - Rule "rule-1" again (creating the cycle)
+`.trim(),
+      ),
+    );
+  });
+
+  it('re-throws any unknown if given a set of rules where a dependency cycle is present', () => {
+    const error = new Error('oops');
+    const depGraph = new dependencyGraphModule.DepGraph();
+    jest.spyOn(depGraph, 'overallOrder').mockImplementation(() => {
+      throw error;
+    });
+    jest.spyOn(dependencyGraphModule, 'DepGraph').mockReturnValue(depGraph);
+
+    expect(() => buildRuleTree([])).toThrow(error);
+  });
+
+  it('returns an empty root node if given no rules', () => {
+    const ruleTree = buildRuleTree([]);
+
+    expect(ruleTree).toStrictEqual({
+      children: [],
+    });
+  });
+});

--- a/src/build-rule-tree.ts
+++ b/src/build-rule-tree.ts
@@ -1,0 +1,142 @@
+import { getErrorMessage } from '@metamask/utils/node';
+import { DepGraph } from 'dependency-graph';
+
+import type { Rule } from './execute-rules';
+import { createModuleLogger, projectLogger } from './logging-utils';
+import { indent } from './misc-utils';
+
+const log = createModuleLogger(projectLogger, 'build-rule-tree');
+
+/**
+ * A rule in the rule tree.
+ */
+export type RuleNode = {
+  rule: Rule;
+  children: RuleNode[];
+};
+
+/**
+ * The "bottom" of the rule tree, as it were. Really here just to satisfy the
+ * definition of a tree (which can't have more than one trunk).
+ */
+type RootRuleNode = {
+  children: RuleNode[];
+};
+
+/**
+ * Some rules are dependent on other rules to execute. For instance, if a rule
+ * is checking for a property within `tsconfig.json`, another rule that checks
+ * for the existence of `tsconfig.json` may need to be executed first. To
+ * determine the execution priority, we need to create a tree structure. The
+ * root of this tree is a dummy node whose children are all of the rules that do
+ * not depend on any other rules to execute. Some of these nodes may have
+ * children, which are the dependents of the rules represented by those nodes.
+ *
+ * @param rules - The rules to rearrange into a tree.
+ * @returns The rule tree.
+ */
+export function buildRuleTree(rules: readonly Rule[]): RootRuleNode {
+  const graph = new DepGraph<Rule>();
+
+  // Add all of the rules to the graph first so that they are available
+  rules.forEach((rule) => {
+    log(`Adding to graph: ${rule.name}`);
+    graph.addNode(rule.name, rule);
+  });
+
+  // Now we specify the connections between nodes
+  rules.forEach((rule) => {
+    rule.dependencies.forEach((dependencyName) => {
+      log(`Adding connection to graph: ${rule.name} -> ${dependencyName}`);
+      graph.addDependency(rule.name, dependencyName);
+    });
+  });
+
+  checkForDependencyCycle(graph);
+
+  const nodesWithoutDependencies = graph.overallOrder(true);
+  const children = buildRuleNodes(graph, nodesWithoutDependencies);
+
+  return { children };
+}
+
+/**
+ * The `dependency-graph` package will throw an error if it detects a dependency
+ * cycle in the graph (i.e., a node that depends on another node, which depends
+ * on the first node). It is impossible to turn a circular graph into a tree,
+ * as it would take forever (literally) to iterate through it. We take advantage
+ * of this to look for dependency cycles in the graph we've build from the rules
+ * and throw a similar error.
+ *
+ * @param graph - The graph made up of rules.
+ * @throws If a dependency cycle is present.
+ */
+function checkForDependencyCycle(graph: DepGraph<Rule>): void {
+  try {
+    graph.overallOrder();
+  } catch (error) {
+    const message = getErrorMessage(error);
+    const match = /^Dependency Cycle Found: (.+)$/u.exec(message);
+
+    if (match?.[1]) {
+      const nodesInCycle = match[1].split(' -> ');
+      const lines = [
+        'Could not build rule tree as some rules depend on each other circularly:',
+        '',
+        ...nodesInCycle.map((node, i) => {
+          let line = `- Rule "${node}"`;
+          if (i === 0) {
+            line += ' depends on...';
+          } else if (i === nodesInCycle.length - 1) {
+            line += ' again (creating the cycle)';
+          } else {
+            line += ', which depends on...';
+          }
+          return indent(line, i);
+        }),
+      ];
+      throw new Error(lines.join('\n'));
+    } else {
+      throw error;
+    }
+  }
+}
+
+/**
+ * Converts a series of node in the rule _graph_ into nodes into the rule
+ * _tree_. This function is called two ways: once when first building the tree
+ * for the rules that don't depend on any other rules, and then each time a
+ * rule's dependents are seen.
+ *
+ * @param graph - The rule graph.
+ * @param nodeNames - The names of rules in the graph to convert.
+ * @returns The built rule nodes.
+ * @see {@link buildRuleNode}
+ */
+function buildRuleNodes(
+  graph: DepGraph<Rule>,
+  nodeNames: string[],
+): RuleNode[] {
+  return nodeNames.map((nodeName) => buildRuleNode(graph, nodeName));
+}
+
+/**
+ * Converts a node in the rule _graph_ into a node into the rule _tree_. As the
+ * nodes of the graph and the connections of the graph are kept separately, this
+ * function essentially combines them by nesting the rule's dependents under the
+ * rule itself. This function is recursive via `buildRuleNodes`, as doing so
+ * means that all of the dependents for a rule get their own node in the rule
+ * tree too.
+ *
+ * @param graph - The rule graph.
+ * @param nodeName - The name of a rule in the graph.
+ * @returns The built rule node.
+ */
+function buildRuleNode(graph: DepGraph<Rule>, nodeName: string): RuleNode {
+  const rule = graph.getNodeData(nodeName);
+  const dependents = graph.directDependentsOf(nodeName);
+  return {
+    rule,
+    children: buildRuleNodes(graph, dependents),
+  };
+}

--- a/src/execute-rules.test.ts
+++ b/src/execute-rules.test.ts
@@ -1,0 +1,173 @@
+import { mockDeep } from 'jest-mock-extended';
+
+import type { MetaMaskRepository } from './establish-metamask-repository';
+import type { Rule } from './execute-rules';
+import { executeRules } from './execute-rules';
+import { fakeDateOnly } from '../tests/helpers';
+
+describe('executeRules', () => {
+  beforeEach(() => {
+    fakeDateOnly();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('runs all of the given rules in dependency order against the given project and template, capturing their results', async () => {
+    const rules: Rule[] = [
+      {
+        name: 'rule-1',
+        description: 'Description for rule 1',
+        dependencies: ['rule-2'],
+        execute: async ({ fail }) => {
+          return fail([{ message: 'Oops' }]);
+        },
+      },
+      {
+        name: 'rule-2',
+        description: 'Description for rule 2',
+        dependencies: [],
+        execute: async ({ pass }) => {
+          return pass();
+        },
+      },
+    ];
+    const project = mockDeep<MetaMaskRepository>();
+    const template = mockDeep<MetaMaskRepository>();
+
+    const ruleExecutionResultTree = await executeRules({
+      rules,
+      project,
+      template,
+    });
+
+    expect(ruleExecutionResultTree).toMatchObject({
+      children: [
+        expect.objectContaining({
+          result: {
+            ruleName: 'rule-2',
+            ruleDescription: 'Description for rule 2',
+            passed: true,
+          },
+          children: [
+            expect.objectContaining({
+              result: {
+                ruleName: 'rule-1',
+                ruleDescription: 'Description for rule 1',
+                passed: false,
+                failures: [{ message: 'Oops' }],
+              },
+              children: [],
+            }),
+          ],
+        }),
+      ],
+    });
+  });
+
+  it("does not run a rule's children if it fails", async () => {
+    const rules: Rule[] = [
+      {
+        name: 'rule-1',
+        description: 'Description for rule 1',
+        dependencies: ['rule-2'],
+        execute: async ({ pass }) => {
+          return pass();
+        },
+      },
+      {
+        name: 'rule-2',
+        description: 'Description for rule 2',
+        dependencies: [],
+        execute: async ({ fail }) => {
+          return fail([{ message: 'Oops' }]);
+        },
+      },
+    ];
+    const project = mockDeep<MetaMaskRepository>();
+    const template = mockDeep<MetaMaskRepository>();
+
+    const ruleExecutionResultTree = await executeRules({
+      rules,
+      project,
+      template,
+    });
+
+    expect(ruleExecutionResultTree).toMatchObject({
+      children: [
+        expect.objectContaining({
+          result: {
+            ruleName: 'rule-2',
+            ruleDescription: 'Description for rule 2',
+            passed: false,
+            failures: [{ message: 'Oops' }],
+          },
+          children: [],
+        }),
+      ],
+    });
+  });
+
+  it('records the time to run each rule, exclusive and inclusive of its children', async () => {
+    jest.setSystemTime(new Date('2023-01-01T00:00:00Z'));
+
+    const rules: Rule[] = [
+      {
+        name: 'rule-1',
+        description: 'Description for rule 1',
+        dependencies: ['rule-2'],
+        execute: async ({ fail }) => {
+          jest.setSystemTime(new Date('2023-01-01T00:00:02Z'));
+          return fail([{ message: 'Oops' }]);
+        },
+      },
+      {
+        name: 'rule-2',
+        description: 'Description for rule 2',
+        dependencies: [],
+        execute: async ({ pass }) => {
+          jest.setSystemTime(new Date('2023-01-01T00:00:01Z'));
+          return pass();
+        },
+      },
+    ];
+    const project = mockDeep<MetaMaskRepository>();
+    const template = mockDeep<MetaMaskRepository>();
+
+    const ruleExecutionResultTree = await executeRules({
+      rules,
+      project,
+      template,
+    });
+
+    expect(ruleExecutionResultTree).toMatchObject({
+      children: [
+        expect.objectContaining({
+          elapsedTimeExcludingChildren: 1000,
+          elapsedTimeIncludingChildren: 2000,
+          children: [
+            expect.objectContaining({
+              elapsedTimeExcludingChildren: 1000,
+              elapsedTimeIncludingChildren: 1000,
+            }),
+          ],
+        }),
+      ],
+    });
+  });
+
+  it('does nothing, returning an empty tree, if given no rules', async () => {
+    const rules: Rule[] = [];
+    const project = mockDeep<MetaMaskRepository>();
+    const template = mockDeep<MetaMaskRepository>();
+
+    const ruleExecutionResultTree = await executeRules({
+      rules,
+      project,
+      template,
+    });
+
+    expect(ruleExecutionResultTree).toStrictEqual({ children: [] });
+  });
+});

--- a/src/execute-rules.ts
+++ b/src/execute-rules.ts
@@ -1,0 +1,245 @@
+import { inspect } from 'util';
+
+import type { RuleNode } from './build-rule-tree';
+import { buildRuleTree } from './build-rule-tree';
+import type { MetaMaskRepository } from './establish-metamask-repository';
+import { createModuleLogger, projectLogger } from './logging-utils';
+
+const log = createModuleLogger(projectLogger, 'establish-metamask-repository');
+
+/**
+ * Represents a successfully executed rule. ("Partial" because a full result
+ * include the name and description of the rule.)
+ */
+export type SuccessfulPartialRuleExecutionResult = {
+  passed: true;
+};
+
+/**
+ * Clarifies why a rule failed.
+ */
+export type RuleExecutionFailure = {
+  message: string;
+};
+
+/**
+ * Represents an unsuccessfully executed rule. ("Partial" because a full result
+ * include the name and description of the rule.)
+ */
+export type FailedPartialRuleExecutionResult = {
+  passed: false;
+  failures: RuleExecutionFailure[];
+};
+
+/**
+ * Represents the result of an executed rule. ("Partial" because a full result
+ * include the name and description of the rule.)
+ */
+export type PartialRuleExecutionResult =
+  | SuccessfulPartialRuleExecutionResult
+  | FailedPartialRuleExecutionResult;
+
+/**
+ * All of the information that designates the result of a rule execution.
+ */
+export type RuleExecutionResult = PartialRuleExecutionResult & {
+  ruleName: string;
+  ruleDescription: string;
+};
+
+/**
+ * A node in the rule execution result tree.
+ */
+export type RuleExecutionResultNode = {
+  result: RuleExecutionResult;
+  elapsedTimeExcludingChildren: number;
+  elapsedTimeIncludingChildren: number;
+  children: RuleExecutionResultNode[];
+};
+
+/**
+ * The "bottom" of the rule execution result tree, as it were. Really here just
+ * to satisfy the definition of a tree (which can't have more than one trunk).
+ */
+export type RootRuleExecutionResultNode = {
+  children: RuleExecutionResultNode[];
+};
+
+/**
+ * A lint rule that can be executed against a project.
+ */
+export type Rule = {
+  /**
+   * The name of the rule, used an internal reference.
+   */
+  name: string;
+  /**
+   * The description of the rule. This will show up when listing rules as a part
+   * of the lint report for a project.
+   */
+  description: string;
+  /**
+   * The names of rules that must be executed first before executing this one.
+   */
+  dependencies: string[];
+  /**
+   * The "body" of the rule.
+   */
+  execute(args: {
+    project: MetaMaskRepository;
+    template: MetaMaskRepository;
+    pass: () => SuccessfulPartialRuleExecutionResult;
+    fail: (
+      failures: FailedPartialRuleExecutionResult['failures'],
+    ) => FailedPartialRuleExecutionResult;
+  }): Promise<PartialRuleExecutionResult>;
+};
+
+/**
+ * Executes the given lint rules against a project, using a template as a
+ * reference.
+ *
+ * @param args - The arguments to this function.
+ * @param args.rules - The rules to execute.
+ * @param args.project - The project repository to execute the rules against.
+ * @param args.template - The template repository to compare the project to.
+ * @returns The results from executing the rules.
+ */
+export async function executeRules({
+  rules,
+  project,
+  template,
+}: {
+  rules: readonly Rule[];
+  project: MetaMaskRepository;
+  template: MetaMaskRepository;
+}): Promise<RootRuleExecutionResultNode> {
+  const ruleTree = buildRuleTree(rules);
+  const resultExecutionResultNodes = await executeRuleNodes({
+    ruleNodes: ruleTree.children,
+    project,
+    template,
+  });
+  return { children: resultExecutionResultNodes };
+}
+
+/**
+ * Given a set of rules as part of a rule tree, executes the rules along with
+ * any children rules, storing the results in a similarly structured set of
+ * nodes. This function is recursive via `executeRule`.
+ *
+ * @param args - The arguments to this function.
+ * @param args.ruleNodes - The nodes of a rule tree that hold the rules.
+ * @param args.project - The project repository to execute the rules against.
+ * @param args.template - The template repository to compare the project to.
+ * @returns The results from executing the rules, as nodes in a tree.
+ */
+export async function executeRuleNodes({
+  ruleNodes,
+  project,
+  template,
+}: {
+  ruleNodes: RuleNode[];
+  project: MetaMaskRepository;
+  template: MetaMaskRepository;
+}): Promise<RuleExecutionResultNode[]> {
+  const ruleExecutionResultNodes: RuleExecutionResultNode[] = [];
+  for (const ruleNode of ruleNodes) {
+    ruleExecutionResultNodes.push(
+      await executeRule({ ruleNode, project, template }),
+    );
+  }
+  return ruleExecutionResultNodes;
+}
+
+/**
+ * Given the node of a rule tree, executes the rule that it refers to, along
+ * with any children rules, against the project. This function is recursive via
+ * `executeRuleNodes`.
+ *
+ * @param args - The arguments to this function.
+ * @param args.ruleNode - The node of a rule tree.
+ * @param args.project - The project repository to execute the rule against.
+ * @param args.template - The template repository to compare the project to.
+ * @returns The result from executing the rule, placed in a similar node shape
+ * as the rule node.
+ */
+async function executeRule({
+  ruleNode,
+  project,
+  template,
+}: {
+  ruleNode: RuleNode;
+  project: MetaMaskRepository;
+  template: MetaMaskRepository;
+}): Promise<RuleExecutionResultNode> {
+  log('Running rule', ruleNode.rule.name);
+  const startDate = new Date();
+
+  const partialRuleExecutionResult = await ruleNode.rule.execute({
+    project,
+    template,
+    pass,
+    fail,
+  });
+  const ruleExecutionResult: RuleExecutionResult = {
+    ruleName: ruleNode.rule.name,
+    ruleDescription: ruleNode.rule.description,
+    ...partialRuleExecutionResult,
+  };
+  log(
+    'Result for',
+    ruleNode.rule.name,
+    inspect(ruleExecutionResult, { depth: null }),
+  );
+  const endDateBeforeChildren = new Date();
+
+  const children: RuleExecutionResultNode[] =
+    ruleExecutionResult.passed && ruleNode.children.length > 0
+      ? await executeRuleNodes({
+          ruleNodes: ruleNode.children,
+          project,
+          template,
+        })
+      : [];
+  const endDateAfterChildren = new Date();
+
+  const elapsedTimeExcludingChildren =
+    endDateBeforeChildren.getTime() - startDate.getTime();
+  const elapsedTimeIncludingChildren =
+    endDateAfterChildren.getTime() - startDate.getTime();
+
+  return {
+    result: ruleExecutionResult,
+    elapsedTimeExcludingChildren,
+    elapsedTimeIncludingChildren,
+    children,
+  };
+}
+
+/**
+ * A helper intended to be used in a rule which ends its execution by marking it
+ * as passing.
+ *
+ * @returns Part of a successful rule execution result (the rest will be filled
+ * in automatically).
+ */
+function pass(): SuccessfulPartialRuleExecutionResult {
+  return {
+    passed: true,
+  };
+}
+
+/**
+ * A helper intended to be used in a rule which ends its execution by marking it
+ * as failing.
+ *
+ * @param failures - The list of associated failures.
+ * @returns Part of a failed rule execution result (the rest will be filled
+ * in automatically).
+ */
+function fail(
+  failures: FailedPartialRuleExecutionResult['failures'],
+): FailedPartialRuleExecutionResult {
+  return { passed: false, failures };
+}

--- a/src/misc-utils.test.ts
+++ b/src/misc-utils.test.ts
@@ -2,7 +2,7 @@ import { writeFile } from '@metamask/utils/node';
 import fs from 'fs';
 import path from 'path';
 
-import { getEntryStats } from './misc-utils';
+import { getEntryStats, indent } from './misc-utils';
 import { withinSandbox } from '../tests/helpers';
 
 describe('getEntryStats', () => {
@@ -60,5 +60,11 @@ describe('getEntryStats', () => {
         }
       });
     });
+  });
+});
+
+describe('indent', () => {
+  it('returns the given string with the given number of spaces (times 2) before it', () => {
+    expect(indent('hello', 4)).toBe('        hello');
   });
 });

--- a/src/misc-utils.ts
+++ b/src/misc-utils.ts
@@ -25,3 +25,18 @@ export async function getEntryStats(
     );
   }
 }
+
+/**
+ * Applies indentation to the given text.
+ *
+ * @param text - The text to indent.
+ * @param level - The indentation level to apply (one level is two spaces).
+ * @returns The indented string.
+ */
+export function indent(text: string, level: number) {
+  let indentation = '';
+  for (let i = 0; i < level * 2; i++) {
+    indentation += ' ';
+  }
+  return `${indentation}${text}`;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,6 +1004,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.43.0
     "@typescript-eslint/parser": ^5.43.0
     depcheck: ^1.4.3
+    dependency-graph: ^0.11.0
     eslint: ^8.44.0
     eslint-config-prettier: ^8.8.0
     eslint-plugin-import: ^2.27.5
@@ -2779,6 +2780,13 @@ __metadata:
   version: 1.1.2
   resolution: "depd@npm:1.1.2"
   checksum: 6b406620d269619852885ce15965272b829df6f409724415e0002c8632ab6a8c0a08ec1f0bd2add05dc7bd7507606f7e2cc034fa24224ab829580040b835ecd9
+  languageName: node
+  linkType: hard
+
+"dependency-graph@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "dependency-graph@npm:0.11.0"
+  checksum: 477204beaa9be69e642bc31ffe7a8c383d0cf48fa27acbc91c5df01431ab913e65c154213d2ef83d034c98d77280743ec85e5da018a97a18dd43d3c0b78b28cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This commit adds code which will be used to run rules against a particular project. This first involves looking at the dependencies between the rules to determine the priority and order in which they should be run, then representing the hierarchy as a tree structure. After that, the tree is merely traversed.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Fixes #35.

See this file for more context on how this will be used: https://github.com/MetaMask/module-lint/blob/add-initial-code/src/lint-project.ts. And see here for an example rule: https://github.com/MetaMask/module-lint/blob/add-initial-code/src/rules/require-source-directory.ts