### PR TITLE
Add checks for Node version compliance

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -77,7 +77,7 @@ describe('main', () => {
           );
           await writeFile(
             path.join(repository.directoryPath, 'README.md'),
-            'Install [Yarn whatever](...)',
+            'Install [Yarn whatever](...) Install the current LTS version of [Node.js](https://nodejs.org)',
           );
           await writeFile(
             path.join(repository.directoryPath, '.nvmrc'),
@@ -108,12 +108,13 @@ repo-1
   - Does the \`engines.node\` field in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
+  - Does the README conform by recommending node install from nodejs.org? ✅
 - Are all of the files for Yarn Modern present, and do they conform? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
 - Is \`.nvmrc\` present, and conform? ✅
 
-Results:       10 passed, 0 failed, 10 total
+Results:       11 passed, 0 failed, 11 total
 Elapsed time:  0 ms
 
 
@@ -126,12 +127,13 @@ repo-2
   - Does the \`engines.node\` field in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
+  - Does the README conform by recommending node install from nodejs.org? ✅
 - Are all of the files for Yarn Modern present, and do they conform? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
 - Is \`.nvmrc\` present, and conform? ✅
 
-Results:       10 passed, 0 failed, 10 total
+Results:       11 passed, 0 failed, 11 total
 Elapsed time:  0 ms
 
 `,
@@ -339,7 +341,7 @@ Elapsed time:  0 ms
           );
           await writeFile(
             path.join(repository.directoryPath, 'README.md'),
-            'Install [Yarn whatever](...)',
+            'Install [Yarn whatever](...) Install the current LTS version of [Node.js](https://nodejs.org)',
           );
           await writeFile(
             path.join(repository.directoryPath, '.nvmrc'),
@@ -370,12 +372,13 @@ repo-1
   - Does the \`engines.node\` field in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
+  - Does the README conform by recommending node install from nodejs.org? ✅
 - Are all of the files for Yarn Modern present, and do they conform? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
 - Is \`.nvmrc\` present, and conform? ✅
 
-Results:       10 passed, 0 failed, 10 total
+Results:       11 passed, 0 failed, 11 total
 Elapsed time:  0 ms
 
 
@@ -388,12 +391,13 @@ repo-2
   - Does the \`engines.node\` field in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
+  - Does the README conform by recommending node install from nodejs.org? ✅
 - Are all of the files for Yarn Modern present, and do they conform? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
 - Is \`.nvmrc\` present, and conform? ✅
 
-Results:       10 passed, 0 failed, 10 total
+Results:       11 passed, 0 failed, 11 total
 Elapsed time:  0 ms
 
 `,

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -76,6 +76,10 @@ describe('main', () => {
             path.join(repository.directoryPath, 'README.md'),
             'Install [Yarn whatever](...)',
           );
+          await writeFile(
+            path.join(repository.directoryPath, '.nvmrc'),
+            'content for .nvmrc',
+          );
         }
         const outputLogger = new FakeOutputLogger();
 
@@ -103,8 +107,9 @@ repo-1
 - Are all of the files for Yarn Modern present, and do they conform? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
+- Is \`.nvmrc\` present, and conform? ✅
 
-Results:       8 passed, 0 failed, 8 total
+Results:       9 passed, 0 failed, 9 total
 Elapsed time:  0 ms
 
 
@@ -119,8 +124,9 @@ repo-2
 - Are all of the files for Yarn Modern present, and do they conform? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
+- Is \`.nvmrc\` present, and conform? ✅
 
-Results:       8 passed, 0 failed, 8 total
+Results:       9 passed, 0 failed, 9 total
 Elapsed time:  0 ms
 
 `,
@@ -177,8 +183,10 @@ repo-1
   - \`.yarn/plugins/\` does not exist in this project.
 - Does the \`src/\` directory exist? ❌
   - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and conform? ❌
+  - \`.nvmrc\` does not exist in this project.
 
-Results:       0 passed, 5 failed, 5 total
+Results:       0 passed, 6 failed, 6 total
 Elapsed time:  0 ms
 
 
@@ -197,8 +205,10 @@ repo-2
   - \`.yarn/plugins/\` does not exist in this project.
 - Does the \`src/\` directory exist? ❌
   - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and conform? ❌
+  - \`.nvmrc\` does not exist in this project.
 
-Results:       0 passed, 5 failed, 5 total
+Results:       0 passed, 6 failed, 6 total
 Elapsed time:  0 ms
 
 `,
@@ -261,8 +271,10 @@ repo-2
   - \`.yarn/plugins/\` does not exist in this project.
 - Does the \`src/\` directory exist? ❌
   - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and conform? ❌
+  - \`.nvmrc\` does not exist in this project.
 
-Results:       1 passed, 4 failed, 5 total
+Results:       1 passed, 5 failed, 6 total
 Elapsed time:  0 ms
 
 `.trimStart(),
@@ -321,6 +333,10 @@ Elapsed time:  0 ms
             path.join(repository.directoryPath, 'README.md'),
             'Install [Yarn whatever](...)',
           );
+          await writeFile(
+            path.join(repository.directoryPath, '.nvmrc'),
+            'content for .nvmrc',
+          );
         }
         const outputLogger = new FakeOutputLogger();
 
@@ -348,8 +364,9 @@ repo-1
 - Are all of the files for Yarn Modern present, and do they conform? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
+- Is \`.nvmrc\` present, and conform? ✅
 
-Results:       8 passed, 0 failed, 8 total
+Results:       9 passed, 0 failed, 9 total
 Elapsed time:  0 ms
 
 
@@ -364,8 +381,9 @@ repo-2
 - Are all of the files for Yarn Modern present, and do they conform? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
+- Is \`.nvmrc\` present, and conform? ✅
 
-Results:       8 passed, 0 failed, 8 total
+Results:       9 passed, 0 failed, 9 total
 Elapsed time:  0 ms
 
 `,
@@ -422,8 +440,10 @@ repo-1
   - \`.yarn/plugins/\` does not exist in this project.
 - Does the \`src/\` directory exist? ❌
   - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and conform? ❌
+  - \`.nvmrc\` does not exist in this project.
 
-Results:       0 passed, 5 failed, 5 total
+Results:       0 passed, 6 failed, 6 total
 Elapsed time:  0 ms
 
 
@@ -442,8 +462,10 @@ repo-2
   - \`.yarn/plugins/\` does not exist in this project.
 - Does the \`src/\` directory exist? ❌
   - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and conform? ❌
+  - \`.nvmrc\` does not exist in this project.
 
-Results:       0 passed, 5 failed, 5 total
+Results:       0 passed, 6 failed, 6 total
 Elapsed time:  0 ms
 
 `,
@@ -505,8 +527,10 @@ repo-2
   - \`.yarn/plugins/\` does not exist in this project.
 - Does the \`src/\` directory exist? ❌
   - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and conform? ❌
+  - \`.nvmrc\` does not exist in this project.
 
-Results:       1 passed, 4 failed, 5 total
+Results:       1 passed, 5 failed, 6 total
 Elapsed time:  0 ms
 
 `,

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -112,7 +112,7 @@ repo-1
 - Are all of the files for Yarn Modern present, and do they conform? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
-- Is \`.nvmrc\` present, and conform? ✅
+- Is \`.nvmrc\` present, and does it conform? ✅
 
 Results:       11 passed, 0 failed, 11 total
 Elapsed time:  0 ms
@@ -131,7 +131,7 @@ repo-2
 - Are all of the files for Yarn Modern present, and do they conform? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
-- Is \`.nvmrc\` present, and conform? ✅
+- Is \`.nvmrc\` present, and does it conform? ✅
 
 Results:       11 passed, 0 failed, 11 total
 Elapsed time:  0 ms
@@ -190,7 +190,7 @@ repo-1
   - \`.yarn/plugins/\` does not exist in this project.
 - Does the \`src/\` directory exist? ❌
   - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and conform? ❌
+- Is \`.nvmrc\` present, and does it conform? ❌
   - \`.nvmrc\` does not exist in this project.
 
 Results:       0 passed, 6 failed, 6 total
@@ -212,7 +212,7 @@ repo-2
   - \`.yarn/plugins/\` does not exist in this project.
 - Does the \`src/\` directory exist? ❌
   - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and conform? ❌
+- Is \`.nvmrc\` present, and does it conform? ❌
   - \`.nvmrc\` does not exist in this project.
 
 Results:       0 passed, 6 failed, 6 total
@@ -278,7 +278,7 @@ repo-2
   - \`.yarn/plugins/\` does not exist in this project.
 - Does the \`src/\` directory exist? ❌
   - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and conform? ❌
+- Is \`.nvmrc\` present, and does it conform? ❌
   - \`.nvmrc\` does not exist in this project.
 
 Results:       1 passed, 5 failed, 6 total
@@ -376,7 +376,7 @@ repo-1
 - Are all of the files for Yarn Modern present, and do they conform? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
-- Is \`.nvmrc\` present, and conform? ✅
+- Is \`.nvmrc\` present, and does it conform? ✅
 
 Results:       11 passed, 0 failed, 11 total
 Elapsed time:  0 ms
@@ -395,7 +395,7 @@ repo-2
 - Are all of the files for Yarn Modern present, and do they conform? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
-- Is \`.nvmrc\` present, and conform? ✅
+- Is \`.nvmrc\` present, and does it conform? ✅
 
 Results:       11 passed, 0 failed, 11 total
 Elapsed time:  0 ms
@@ -454,7 +454,7 @@ repo-1
   - \`.yarn/plugins/\` does not exist in this project.
 - Does the \`src/\` directory exist? ❌
   - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and conform? ❌
+- Is \`.nvmrc\` present, and does it conform? ❌
   - \`.nvmrc\` does not exist in this project.
 
 Results:       0 passed, 6 failed, 6 total
@@ -476,7 +476,7 @@ repo-2
   - \`.yarn/plugins/\` does not exist in this project.
 - Does the \`src/\` directory exist? ❌
   - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and conform? ❌
+- Is \`.nvmrc\` present, and does it conform? ❌
   - \`.nvmrc\` does not exist in this project.
 
 Results:       0 passed, 6 failed, 6 total
@@ -541,7 +541,7 @@ repo-2
   - \`.yarn/plugins/\` does not exist in this project.
 - Does the \`src/\` directory exist? ❌
   - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and conform? ❌
+- Is \`.nvmrc\` present, and does it conform? ❌
   - \`.nvmrc\` does not exist in this project.
 
 Results:       1 passed, 5 failed, 6 total

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -70,7 +70,10 @@ describe('main', () => {
           );
           await writeFile(
             path.join(repository.directoryPath, 'package.json'),
-            JSON.stringify({ packageManager: 'yarn' }),
+            JSON.stringify({
+              packageManager: 'yarn',
+              engines: { node: 'test' },
+            }),
           );
           await writeFile(
             path.join(repository.directoryPath, 'README.md'),
@@ -102,6 +105,7 @@ repo-1
 - Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
 - Does the package have a well-formed manifest (\`package.json\`)? ✅
   - Does the \`packageManager\` field in \`package.json\` conform? ✅
+  - Does the \`engines.node\` field in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Are all of the files for Yarn Modern present, and do they conform? ✅
@@ -109,7 +113,7 @@ repo-1
 - Does the \`src/\` directory exist? ✅
 - Is \`.nvmrc\` present, and conform? ✅
 
-Results:       9 passed, 0 failed, 9 total
+Results:       10 passed, 0 failed, 10 total
 Elapsed time:  0 ms
 
 
@@ -119,6 +123,7 @@ repo-2
 - Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
 - Does the package have a well-formed manifest (\`package.json\`)? ✅
   - Does the \`packageManager\` field in \`package.json\` conform? ✅
+  - Does the \`engines.node\` field in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Are all of the files for Yarn Modern present, and do they conform? ✅
@@ -126,7 +131,7 @@ repo-2
 - Does the \`src/\` directory exist? ✅
 - Is \`.nvmrc\` present, and conform? ✅
 
-Results:       9 passed, 0 failed, 9 total
+Results:       10 passed, 0 failed, 10 total
 Elapsed time:  0 ms
 
 `,
@@ -327,7 +332,10 @@ Elapsed time:  0 ms
           );
           await writeFile(
             path.join(repository.directoryPath, 'package.json'),
-            JSON.stringify({ packageManager: 'yarn' }),
+            JSON.stringify({
+              packageManager: 'yarn',
+              engines: { node: 'test' },
+            }),
           );
           await writeFile(
             path.join(repository.directoryPath, 'README.md'),
@@ -359,6 +367,7 @@ repo-1
 - Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
 - Does the package have a well-formed manifest (\`package.json\`)? ✅
   - Does the \`packageManager\` field in \`package.json\` conform? ✅
+  - Does the \`engines.node\` field in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Are all of the files for Yarn Modern present, and do they conform? ✅
@@ -366,7 +375,7 @@ repo-1
 - Does the \`src/\` directory exist? ✅
 - Is \`.nvmrc\` present, and conform? ✅
 
-Results:       9 passed, 0 failed, 9 total
+Results:       10 passed, 0 failed, 10 total
 Elapsed time:  0 ms
 
 
@@ -376,6 +385,7 @@ repo-2
 - Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
 - Does the package have a well-formed manifest (\`package.json\`)? ✅
   - Does the \`packageManager\` field in \`package.json\` conform? ✅
+  - Does the \`engines.node\` field in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Are all of the files for Yarn Modern present, and do they conform? ✅
@@ -383,7 +393,7 @@ repo-2
 - Does the \`src/\` directory exist? ✅
 - Is \`.nvmrc\` present, and conform? ✅
 
-Results:       9 passed, 0 failed, 9 total
+Results:       10 passed, 0 failed, 10 total
 Elapsed time:  0 ms
 
 `,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -2,6 +2,7 @@ import allYarnModernFilesConform from './all-yarn-modern-files-conform';
 import classicYarnConfigFileAbsent from './classic-yarn-config-file-absent';
 import packageManagerFieldConforms from './package-manager-field-conforms';
 import readmeListsCorrectYarnVersion from './readme-lists-correct-yarn-version';
+import requireNvmrc from './require-nvmrc';
 import requireReadme from './require-readme';
 import requireSourceDirectory from './require-source-directory';
 import requireValidPackageManifest from './require-valid-package-manifest';
@@ -14,4 +15,5 @@ export const rules = [
   requireReadme,
   requireSourceDirectory,
   requireValidPackageManifest,
+  requireNvmrc,
 ] as const;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,5 +1,6 @@
 import allYarnModernFilesConform from './all-yarn-modern-files-conform';
 import classicYarnConfigFileAbsent from './classic-yarn-config-file-absent';
+import packageEnginesNodeFieldConforms from './package-engines-node-field-conforms';
 import packageManagerFieldConforms from './package-manager-field-conforms';
 import readmeListsCorrectYarnVersion from './readme-lists-correct-yarn-version';
 import requireNvmrc from './require-nvmrc';
@@ -16,4 +17,5 @@ export const rules = [
   requireSourceDirectory,
   requireValidPackageManifest,
   requireNvmrc,
+  packageEnginesNodeFieldConforms,
 ] as const;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -3,6 +3,7 @@ import classicYarnConfigFileAbsent from './classic-yarn-config-file-absent';
 import packageEnginesNodeFieldConforms from './package-engines-node-field-conforms';
 import packageManagerFieldConforms from './package-manager-field-conforms';
 import readmeListsCorrectYarnVersion from './readme-lists-correct-yarn-version';
+import readmeListsNodejsWebsite from './readme-recommends-node-install';
 import requireNvmrc from './require-nvmrc';
 import requireReadme from './require-readme';
 import requireSourceDirectory from './require-source-directory';
@@ -18,4 +19,5 @@ export const rules = [
   requireValidPackageManifest,
   requireNvmrc,
   packageEnginesNodeFieldConforms,
+  readmeListsNodejsWebsite,
 ] as const;

--- a/src/rules/package-engines-node-field-conforms.test.ts
+++ b/src/rules/package-engines-node-field-conforms.test.ts
@@ -1,12 +1,12 @@
 import { writeFile } from '@metamask/utils/node';
 import path from 'path';
 
-import packageManagerFieldConforms from './package-manager-field-conforms';
+import packageEnginesNodeFieldConforms from './package-engines-node-field-conforms';
 import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
 import { fail, pass } from '../rule-helpers';
 
-describe('Rule: package-manager-field-conforms', () => {
-  it('passes if the "packageManager" field in the project\'s package.json matches the one in the template\'s package.json', async () => {
+describe('Rule: package-engines-node-field-conforms', () => {
+  it('passes if the "engines.node" field in the project\'s package.json matches the one in the template\'s package.json', async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -25,7 +25,7 @@ describe('Rule: package-manager-field-conforms', () => {
         JSON.stringify({ packageManager: 'a', engines: { node: 'test' } }),
       );
 
-      const result = await packageManagerFieldConforms.execute({
+      const result = await packageEnginesNodeFieldConforms.execute({
         template,
         project,
         pass,
@@ -38,7 +38,7 @@ describe('Rule: package-manager-field-conforms', () => {
     });
   });
 
-  it('fails if the "packageManager" field in the project\'s package.json does not match the one in the template\'s package.json', async () => {
+  it('fails if the "engines.node" field in the project\'s package.json does not match the one in the template\'s package.json', async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -46,7 +46,7 @@ describe('Rule: package-manager-field-conforms', () => {
       });
       await writeFile(
         path.join(template.directoryPath, 'package.json'),
-        JSON.stringify({ packageManager: 'a', engines: { node: 'test' } }),
+        JSON.stringify({ packageManager: 'a', engines: { node: 'test1' } }),
       );
       const project = buildMetaMaskRepository({
         shortname: 'project',
@@ -54,10 +54,10 @@ describe('Rule: package-manager-field-conforms', () => {
       });
       await writeFile(
         path.join(project.directoryPath, 'package.json'),
-        JSON.stringify({ packageManager: 'b', engines: { node: 'test' } }),
+        JSON.stringify({ packageManager: 'a', engines: { node: 'test2' } }),
       );
 
-      const result = await packageManagerFieldConforms.execute({
+      const result = await packageEnginesNodeFieldConforms.execute({
         template,
         project,
         pass,
@@ -67,7 +67,9 @@ describe('Rule: package-manager-field-conforms', () => {
       expect(result).toStrictEqual({
         passed: false,
         failures: [
-          { message: '`packageManager` is "b", when it should be "a".' },
+          {
+            message: '`engines.node` is test2, when it should be test1.',
+          },
         ],
       });
     });

--- a/src/rules/package-engines-node-field-conforms.test.ts
+++ b/src/rules/package-engines-node-field-conforms.test.ts
@@ -68,7 +68,7 @@ describe('Rule: package-engines-node-field-conforms', () => {
         passed: false,
         failures: [
           {
-            message: '`engines.node` is test2, when it should be test1.',
+            message: '`engines.node` is "test2", when it should be "test1".',
           },
         ],
       });

--- a/src/rules/package-engines-node-field-conforms.ts
+++ b/src/rules/package-engines-node-field-conforms.ts
@@ -19,7 +19,7 @@ export default buildRule({
     if (projectManifest.engines.node !== templateManifest.engines.node) {
       return fail([
         {
-          message: `\`engines.node\` is ${projectManifest.engines.node}, when it should be ${templateManifest.engines.node}.`,
+          message: `\`engines.node\` is "${projectManifest.engines.node}", when it should be "${templateManifest.engines.node}".`,
         },
       ]);
     }

--- a/src/rules/package-engines-node-field-conforms.ts
+++ b/src/rules/package-engines-node-field-conforms.ts
@@ -1,0 +1,28 @@
+import { buildRule } from './build-rule';
+import { PackageManifestSchema, RuleName } from './types';
+
+export default buildRule({
+  name: RuleName.PackageEnginesNodeFieldConforms,
+  description: 'Does the `engines.node` field in `package.json` conform?',
+  dependencies: [RuleName.RequireValidPackageManifest],
+  execute: async ({ project, template, pass, fail }) => {
+    const entryPath = 'package.json';
+    const templateManifest = await template.fs.readJsonFileAs(
+      entryPath,
+      PackageManifestSchema,
+    );
+    const projectManifest = await project.fs.readJsonFileAs(
+      entryPath,
+      PackageManifestSchema,
+    );
+
+    if (projectManifest.engines.node !== templateManifest.engines.node) {
+      return fail([
+        {
+          message: `\`engines.node\` is ${projectManifest.engines.node}, when it should be ${templateManifest.engines.node}.`,
+        },
+      ]);
+    }
+    return pass();
+  },
+});

--- a/src/rules/readme-recommends-node-install.test.ts
+++ b/src/rules/readme-recommends-node-install.test.ts
@@ -1,0 +1,110 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import readmeRecommendsNodeInstall from './readme-recommends-node-install';
+import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: readme-recommends-node-install', () => {
+  it("passes if the node install recommendation in the project's README matches the same one in the template", async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'README.md'),
+        'Install the current LTS version of [Node.js](https://nodejs.org)',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'README.md'),
+        'Install the current LTS version of [Node.js](https://nodejs.org)',
+      );
+
+      const result = await readmeRecommendsNodeInstall.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: true,
+      });
+    });
+  });
+
+  it("fails if the node install recommendation in the project's README does not match the same one in the template", async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'README.md'),
+        'Install the current LTS version of [Node.js](https://nodejs.org)',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'README.md'),
+        'Install the current LTS version of [Node.js]',
+      );
+
+      const result = await readmeRecommendsNodeInstall.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message:
+              '`README.md` should contain "Install the current LTS version of [Node.js](https://nodejs.org)", but does not.',
+          },
+        ],
+      });
+    });
+  });
+
+  it('throws if the template does not have the node install recommendation in its README for some reason', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'README.md'),
+        'clearly something else',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'README.md'),
+        'does not matter',
+      );
+
+      await expect(
+        readmeRecommendsNodeInstall.execute({
+          template,
+          project,
+          pass,
+          fail,
+        }),
+      ).rejects.toThrow(
+        "Could not find node install recommendation in template's README. This is not the fault of the project, but is rather a bug in a rule.",
+      );
+    });
+  });
+});

--- a/src/rules/readme-recommends-node-install.ts
+++ b/src/rules/readme-recommends-node-install.ts
@@ -1,0 +1,31 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+
+export default buildRule({
+  name: RuleName.ReadmeRecommendsNodeInstall,
+  description:
+    'Does the README conform by recommending node install from nodejs.org?',
+  dependencies: [RuleName.RequireReadme],
+  execute: async ({ template, project, pass, fail }) => {
+    const entryPath = 'README.md';
+
+    const fileContentInTemplate = await template.fs.readFile(entryPath);
+    const fileContentInProject = await project.fs.readFile(entryPath);
+    const nodeInstallRecommend =
+      'Install the current LTS version of [Node.js](https://nodejs.org)';
+    const includes = fileContentInTemplate.includes(nodeInstallRecommend);
+    if (!includes) {
+      throw new Error(
+        "Could not find node install recommendation in template's README. This is not the fault of the project, but is rather a bug in a rule.",
+      );
+    }
+    if (!fileContentInProject.includes(nodeInstallRecommend)) {
+      return fail([
+        {
+          message: `\`README.md\` should contain "${nodeInstallRecommend}", but does not.`,
+        },
+      ]);
+    }
+    return pass();
+  },
+});

--- a/src/rules/require-nvmrc.test.ts
+++ b/src/rules/require-nvmrc.test.ts
@@ -6,7 +6,7 @@ import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
 import { fail, pass } from '../rule-helpers';
 
 describe('Rule: require-nvmrc', () => {
-  it('lint passes if the project has a .nvmrc', async () => {
+  it('passes if the project has a .nvmrc', async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -38,7 +38,7 @@ describe('Rule: require-nvmrc', () => {
     });
   });
 
-  it('lint fails with failure message when .nvmrc does not exist', async () => {
+  it('fails with failure message when .nvmrc does not exist', async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',

--- a/src/rules/require-nvmrc.test.ts
+++ b/src/rules/require-nvmrc.test.ts
@@ -1,0 +1,73 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import requireNvmrc from './require-nvmrc';
+import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: require-nvmrc', () => {
+  it('lint passes if the project has a .nvmrc', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.nvmrc'),
+        'contents of nvmrc',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, '.nvmrc'),
+        'contents of nvmrc',
+      );
+
+      const result = await requireNvmrc.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: true,
+      });
+    });
+  });
+
+  it('lint fails with failure message when .nvmrc does not exist', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.nvmrc'),
+        'contents of nvmrc',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+
+      const result = await requireNvmrc.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message: '`.nvmrc` does not exist in this project.',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/rules/require-nvmrc.ts
+++ b/src/rules/require-nvmrc.ts
@@ -4,7 +4,7 @@ import { fileConforms } from '../rule-helpers';
 
 export default buildRule({
   name: RuleName.RequireNvmrc,
-  description: 'Is `.nvmrc` present, and conform?',
+  description: 'Is `.nvmrc` present, and does it conform?',
   dependencies: [],
   execute: async (ruleExecutionArguments) => {
     return await fileConforms('.nvmrc', ruleExecutionArguments);

--- a/src/rules/require-nvmrc.ts
+++ b/src/rules/require-nvmrc.ts
@@ -1,0 +1,12 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { fileConforms } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.RequireNvmrc,
+  description: 'Is `.nvmrc` present, and conform?',
+  dependencies: [],
+  execute: async (ruleExecutionArguments) => {
+    return await fileConforms('.nvmrc', ruleExecutionArguments);
+  },
+});

--- a/src/rules/require-valid-package-manifest.test.ts
+++ b/src/rules/require-valid-package-manifest.test.ts
@@ -14,7 +14,7 @@ describe('Rule: require-package-manifest', () => {
       });
       await writeFile(
         path.join(project.directoryPath, 'package.json'),
-        JSON.stringify({ packageManager: 'foo' }),
+        JSON.stringify({ packageManager: 'foo', engines: { node: 'test' } }),
       );
 
       const result = await requireValidPackageManifest.execute({
@@ -76,7 +76,10 @@ describe('Rule: require-package-manifest', () => {
       expect(result).toStrictEqual({
         passed: false,
         failures: [
-          { message: 'Invalid `package.json`: Missing `packageManager`.' },
+          {
+            message:
+              'Invalid `package.json`: Missing `packageManager`; Missing `engines`.',
+          },
         ],
       });
     });

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -13,6 +13,7 @@ export enum RuleName {
   RequireValidPackageManifest = 'require-valid-package-manifest',
   RequireNvmrc = 'require-nvmrc',
   PackageEnginesNodeFieldConforms = 'package-engines-node-field-conforms',
+  ReadmeRecommendsNodeInstall = 'readme-recommends-node-install',
 }
 
 export const PackageManifestSchema = type({

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -12,8 +12,12 @@ export enum RuleName {
   RequireSourceDirectory = 'require-source-directory',
   RequireValidPackageManifest = 'require-valid-package-manifest',
   RequireNvmrc = 'require-nvmrc',
+  PackageEnginesNodeFieldConforms = 'package-engines-node-field-conforms',
 }
 
 export const PackageManifestSchema = type({
   packageManager: string(),
+  engines: type({
+    node: string(),
+  }),
 });

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -11,6 +11,7 @@ export enum RuleName {
   RequireReadme = 'require-readme',
   RequireSourceDirectory = 'require-source-directory',
   RequireValidPackageManifest = 'require-valid-package-manifest',
+  RequireNvmrc = 'require-nvmrc',
 }
 
 export const PackageManifestSchema = type({


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
For any given project, we want to verify the following to make sure node version compliance:

* .nvmrc should exist, and its contents should match the same file in the module template
* The engines.node property in package.json should exist, and should match the same value as in the module template
* The README should include a line - Install the current LTS version of [Node.js](https://nodejs.org).

Fixes #12 