### PR TITLE
Flatten rules when reporting execution results

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -194,7 +194,7 @@ repo-1
 - Is \`tsup.config.ts\` present, and does it conform? ✅
 - Is \`typedoc.json\` present, and does it conform? ✅
 - Is \`CHANGELOG.md\` present? ✅
-  - Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`CHANGELOG.md\` well-formatted? ✅
 
 Results:       33 passed, 0 failed, 33 total
 Elapsed time:  0 ms
@@ -235,7 +235,7 @@ repo-2
 - Is \`tsup.config.ts\` present, and does it conform? ✅
 - Is \`typedoc.json\` present, and does it conform? ✅
 - Is \`CHANGELOG.md\` present? ✅
-  - Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`CHANGELOG.md\` well-formatted? ✅
 
 Results:       33 passed, 0 failed, 33 total
 Elapsed time:  0 ms
@@ -583,7 +583,7 @@ repo-1
 - Is \`tsup.config.ts\` present, and does it conform? ✅
 - Is \`typedoc.json\` present, and does it conform? ✅
 - Is \`CHANGELOG.md\` present? ✅
-  - Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`CHANGELOG.md\` well-formatted? ✅
 
 Results:       33 passed, 0 failed, 33 total
 Elapsed time:  0 ms
@@ -624,7 +624,7 @@ repo-2
 - Is \`tsup.config.ts\` present, and does it conform? ✅
 - Is \`typedoc.json\` present, and does it conform? ✅
 - Is \`CHANGELOG.md\` present? ✅
-  - Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`CHANGELOG.md\` well-formatted? ✅
 
 Results:       33 passed, 0 failed, 33 total
 Elapsed time:  0 ms

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -97,11 +97,11 @@ repo-1
 
 - Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
 - Does the package have a well-formed manifest (\`package.json\`)? ✅
-  - Does the \`packageManager\` field in \`package.json\` conform? ✅
+- Does the \`packageManager\` field in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
-  - Does the README conform by recommending the correct Yarn version to install? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
 - Are all of the files for Yarn Modern present, and do they conform? ✅
-  - Does the README conform by recommending the correct Yarn version to install? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
 
 Results:       8 passed, 0 failed, 8 total
@@ -113,11 +113,11 @@ repo-2
 
 - Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
 - Does the package have a well-formed manifest (\`package.json\`)? ✅
-  - Does the \`packageManager\` field in \`package.json\` conform? ✅
+- Does the \`packageManager\` field in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
-  - Does the README conform by recommending the correct Yarn version to install? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
 - Are all of the files for Yarn Modern present, and do they conform? ✅
-  - Does the README conform by recommending the correct Yarn version to install? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
 
 Results:       8 passed, 0 failed, 8 total
@@ -342,11 +342,11 @@ repo-1
 
 - Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
 - Does the package have a well-formed manifest (\`package.json\`)? ✅
-  - Does the \`packageManager\` field in \`package.json\` conform? ✅
+- Does the \`packageManager\` field in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
-  - Does the README conform by recommending the correct Yarn version to install? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
 - Are all of the files for Yarn Modern present, and do they conform? ✅
-  - Does the README conform by recommending the correct Yarn version to install? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
 
 Results:       8 passed, 0 failed, 8 total
@@ -358,11 +358,11 @@ repo-2
 
 - Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
 - Does the package have a well-formed manifest (\`package.json\`)? ✅
-  - Does the \`packageManager\` field in \`package.json\` conform? ✅
+- Does the \`packageManager\` field in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
-  - Does the README conform by recommending the correct Yarn version to install? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
 - Are all of the files for Yarn Modern present, and do they conform? ✅
-  - Does the README conform by recommending the correct Yarn version to install? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
 
 Results:       8 passed, 0 failed, 8 total

--- a/src/report-project-lint-result.test.ts
+++ b/src/report-project-lint-result.test.ts
@@ -3,7 +3,7 @@ import { reportProjectLintResult } from './report-project-lint-result';
 import { FakeOutputLogger } from '../tests/fake-output-logger';
 
 describe('reportProjectLintResult', () => {
-  it('outputs the rules executed against a project, in the same hierarchy as they were run, and whether they passed or failed, along with a summary', () => {
+  it('outputs the rules executed against a project and whether they passed or failed, along with a summary', () => {
     const projectLintResult: ProjectLintResult = {
       projectName: 'some-project',
       elapsedTimeIncludingLinting: 30,
@@ -61,9 +61,9 @@ some-project
 ------------
 
 - Description for rule 1 ✅
-  - Description for rule 2 ❌
-    - Failure 1
-    - Failure 2
+- Description for rule 2 ❌
+  - Failure 1
+  - Failure 2
 - Description for rule 3 ✅
 
 Results:       2 passed, 1 failed, 3 total

--- a/src/report-project-lint-result.ts
+++ b/src/report-project-lint-result.ts
@@ -65,39 +65,29 @@ export function reportProjectLintResult({
 }
 
 /**
- * Prints the results from rules executed against a project. These results are
- * organized in a tree structure just like their rules, so they will be
- * displayed in the same structure. This function is recursive, as each rule
- * execution result node may have children.
+ * Prints the results from rules executed against a project.
  *
  * @param args - The arguments to this function.
  * @param args.ruleExecutionResultNodes - The nodes within the rule execution
  * result tree.
- * @param args.level - The level in the tree we are currently at (this governed
- * how the results are indented as they are displayed).
  * @param args.outputLogger - Writable streams for output messages.
  * @returns The total number of passing and failing rules encountered.
  */
 function reportRuleExecutionResultNodes({
   ruleExecutionResultNodes,
   outputLogger,
-  level = 0,
 }: {
   ruleExecutionResultNodes: RuleExecutionResultNode[];
   outputLogger: AbstractOutputLogger;
-  level?: number;
 }) {
   let numberOfPassing = 0;
   let numberOfFailing = 0;
 
   for (const ruleExecutionResultNode of ruleExecutionResultNodes) {
     outputLogger.logToStdout(
-      indent(
-        `- ${ruleExecutionResultNode.result.ruleDescription} ${
-          ruleExecutionResultNode.result.passed ? '✅' : '❌'
-        }`,
-        level,
-      ),
+      `- ${ruleExecutionResultNode.result.ruleDescription} ${
+        ruleExecutionResultNode.result.passed ? '✅' : '❌'
+      }`,
     );
 
     if (ruleExecutionResultNode.result.passed) {
@@ -107,7 +97,7 @@ function reportRuleExecutionResultNodes({
 
       for (const failure of ruleExecutionResultNode.result.failures) {
         outputLogger.logToStdout(
-          indent(`- ${chalk.yellow(failure.message)}`, level + 1),
+          indent(`- ${chalk.yellow(failure.message)}`, 1),
         );
       }
     }
@@ -118,7 +108,6 @@ function reportRuleExecutionResultNodes({
     } = reportRuleExecutionResultNodes({
       ruleExecutionResultNodes: ruleExecutionResultNode.children,
       outputLogger,
-      level: level + 1,
     });
     numberOfPassing += numberOfChildrenPassing;
     numberOfFailing += numberOfChildrenFailing;


### PR DESCRIPTION
Rules are arranged in a tree structure before being executed, so that dependent rules are executed before their dependencies. Currently, the report which summarizes the results of executing rules is arranged in the same tree structure, with dependencies indented under their dependents. While this could be interesting to some users, it is not necessary. This commit flattens the list when reporting.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

For instance, here is the output for `yarn run-tool utils` before this change:

```
- Is the classic Yarn config file (`.yarnrc`) absent? ✅
- Does the package have a well-formed manifest (`package.json`)? ✅
  - Does the `packageManager` field in `package.json` conform? ❌
    - `packageManager` is "yarn@3.2.3", when it should be "yarn@3.2.1".
  - Does the `engines.node` field in `package.json` conform? ❌
    - `engines.node` is ">=16.0.0", when it should be "^18.18 || >=20".
  - Do the lint-related `devDependencies` in `package.json` conform? ❌
    - `@metamask/eslint-config-jest` is "^12.0.0", when it should be "^12.1.0".
    - `@metamask/eslint-config-nodejs` is "^12.0.0", when it should be "^12.1.0".
    - `@metamask/eslint-config-typescript` is "^12.0.0", when it should be "^12.1.0".
    - `eslint-plugin-import` is "^2.27.5", when it should be "~2.26.0".
  - Do the jest-related `devDependencies` in `package.json` conform? ❌
    - `jest` is "^29.2.2", when it should be "^28.1.3".
  - Do the test-related `scripts` in `package.json` conform? ❌
    - `scripts.[test]` is 'yarn test:source && yarn test:types', when it should be 'jest && jest-it-up'.
  - Do the typescript-related `devDependencies` in `package.json` conform? ❌
    - `devDependencies.[@types/node]` is '^17.0.23', when it should be '^16'.
  - Do the typescript-related `scripts` in `package.json` conform? ❌
    - `scripts.[build]` is 'tsup && yarn build:types', when it should be 'tsup --clean && yarn build:types'.
  - Does the `exports` field in `package.json` conform? ✅
  - Does the `main` field in `package.json` conform? ✅
  - Does the `module` field in `package.json` conform? ✅
  - Does the `types` field in `package.json` conform? ✅
  - Does the `files` field in `package.json` conform? ✅
  - Does LavaMoat allow scripts for `tsup>esbuild`? ✅
  - Do the typedoc-related `devDependencies` in `package.json` conform? ✅
  - Do the typedoc-related `scripts` in `package.json` conform? ✅
- Is `README.md` present? ✅
  - Does the README conform by recommending the correct Yarn version to install? ✅
  - Does the README conform by recommending node install from nodejs.org? ❌
    - `README.md` should contain "Install the current LTS version of [Node.js](https://nodejs.org)", but does not.
- Are all of the files for Yarn Modern present, and do they conform? ❌
  - `.yarnrc.yml` does not match the same file in the template repo.
  - `.yarn/releases/yarn-3.2.1.cjs` does not exist in this project.
  - `.yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs` does not match the same file in the template repo.
  - `.yarn/plugins/@yarnpkg/plugin-constraints.cjs` does not match the same file in the template repo.
- Does the `src/` directory exist? ✅
- Is `.nvmrc` present, and does it conform? ❌
  - `.nvmrc` does not match the same file in the template repo.
- Is `jest.config.js` present, and does it conform? ❌
  - `jest.config.js` does not match the same file in the template repo.
- Is `tsconfig.json` present, and does it conform? ❌
  - `tsconfig.json` does not match the same file in the template repo.
- Is `tsconfig.build.json` present, and does it conform? ✅
- Is `tsup.config.ts` present, and does it conform? ✅
- Is `typedoc.json` present, and does it conform? ✅
```

And here is the output after this change:

```
- Is the classic Yarn config file (`.yarnrc`) absent? ✅
- Does the package have a well-formed manifest (`package.json`)? ✅
- Does the `packageManager` field in `package.json` conform? ❌
  - `packageManager` is "yarn@3.2.3", when it should be "yarn@3.2.1".
- Does the `engines.node` field in `package.json` conform? ❌
  - `engines.node` is ">=16.0.0", when it should be "^18.18 || >=20".
- Do the lint-related `devDependencies` in `package.json` conform? ❌
  - `@metamask/eslint-config-jest` is "^12.0.0", when it should be "^12.1.0".
  - `@metamask/eslint-config-nodejs` is "^12.0.0", when it should be "^12.1.0".
  - `@metamask/eslint-config-typescript` is "^12.0.0", when it should be "^12.1.0".
  - `eslint-plugin-import` is "^2.27.5", when it should be "~2.26.0".
- Do the jest-related `devDependencies` in `package.json` conform? ❌
  - `jest` is "^29.2.2", when it should be "^28.1.3".
- Do the test-related `scripts` in `package.json` conform? ❌
  - `scripts.[test]` is 'yarn test:source && yarn test:types', when it should be 'jest && jest-it-up'.
- Do the typescript-related `devDependencies` in `package.json` conform? ❌
  - `devDependencies.[@types/node]` is '^17.0.23', when it should be '^16'.
- Do the typescript-related `scripts` in `package.json` conform? ❌
  - `scripts.[build]` is 'tsup && yarn build:types', when it should be 'tsup --clean && yarn build:types'.
- Does the `exports` field in `package.json` conform? ✅
- Does the `main` field in `package.json` conform? ✅
- Does the `module` field in `package.json` conform? ✅
- Does the `types` field in `package.json` conform? ✅
- Does the `files` field in `package.json` conform? ✅
- Does LavaMoat allow scripts for `tsup>esbuild`? ✅
- Do the typedoc-related `devDependencies` in `package.json` conform? ✅
- Do the typedoc-related `scripts` in `package.json` conform? ✅
- Is `README.md` present? ✅
- Does the README conform by recommending the correct Yarn version to install? ✅
- Does the README conform by recommending node install from nodejs.org? ❌
  - `README.md` should contain "Install the current LTS version of [Node.js](https://nodejs.org)", but does not.
- Are all of the files for Yarn Modern present, and do they conform? ❌
  - `.yarnrc.yml` does not match the same file in the template repo.
  - `.yarn/releases/yarn-3.2.1.cjs` does not exist in this project.
  - `.yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs` does not match the same file in the template repo.
  - `.yarn/plugins/@yarnpkg/plugin-constraints.cjs` does not match the same file in the template repo.
- Does the `src/` directory exist? ✅
- Is `.nvmrc` present, and does it conform? ❌
  - `.nvmrc` does not match the same file in the template repo.
- Is `jest.config.js` present, and does it conform? ❌
  - `jest.config.js` does not match the same file in the template repo.
- Is `tsconfig.json` present, and does it conform? ❌
  - `tsconfig.json` does not match the same file in the template repo.
- Is `tsconfig.build.json` present, and does it conform? ✅
- Is `tsup.config.ts` present, and does it conform? ✅
- Is `typedoc.json` present, and does it conform? ✅
```