### PR TITLE
to be consistent across the file naming, package has be prefixed

### DIFF
--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,7 +1,7 @@
 import allYarnModernFilesConform from './all-yarn-modern-files-conform';
 import classicYarnConfigFileAbsent from './classic-yarn-config-file-absent';
 import packageEnginesNodeFieldConforms from './package-engines-node-field-conforms';
-import packageManagerFieldConforms from './package-manager-field-conforms';
+import packagePackageManagerFieldConforms from './package-package-manager-field-conforms';
 import readmeListsCorrectYarnVersion from './readme-lists-correct-yarn-version';
 import readmeListsNodejsWebsite from './readme-recommends-node-install';
 import requireNvmrc from './require-nvmrc';
@@ -12,7 +12,7 @@ import requireValidPackageManifest from './require-valid-package-manifest';
 export const rules = [
   allYarnModernFilesConform,
   classicYarnConfigFileAbsent,
-  packageManagerFieldConforms,
+  packagePackageManagerFieldConforms,
   readmeListsCorrectYarnVersion,
   requireReadme,
   requireSourceDirectory,

--- a/src/rules/package-package-manager-field-conforms.test.ts
+++ b/src/rules/package-package-manager-field-conforms.test.ts
@@ -1,7 +1,7 @@
 import { writeFile } from '@metamask/utils/node';
 import path from 'path';
 
-import packageManagerFieldConforms from './package-manager-field-conforms';
+import packageManagerFieldConforms from './package-package-manager-field-conforms';
 import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
 import { fail, pass } from '../rule-helpers';
 

--- a/src/rules/package-package-manager-field-conforms.ts
+++ b/src/rules/package-package-manager-field-conforms.ts
@@ -2,7 +2,7 @@ import { buildRule } from './build-rule';
 import { PackageManifestSchema, RuleName } from './types';
 
 export default buildRule({
-  name: RuleName.PackageManagerFieldConforms,
+  name: RuleName.PackagePackageManagerFieldConforms,
   description: 'Does the `packageManager` field in `package.json` conform?',
   dependencies: [RuleName.RequireValidPackageManifest],
   execute: async ({ project, template, pass, fail }) => {

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -6,7 +6,7 @@ import { type, string } from 'superstruct';
 export enum RuleName {
   AllYarnModernFilesConform = 'all-yarn-modern-files-conform',
   ClassicYarnConfigFileAbsent = 'classic-yarn-config-file-absent',
-  PackageManagerFieldConforms = 'package-manager-field-conforms',
+  PackagePackageManagerFieldConforms = 'package-package-manager-field-conforms',
   ReadmeListsCorrectYarnVersion = 'readme-lists-correct-yarn-version',
   RequireReadme = 'require-readme',
   RequireSourceDirectory = 'require-source-directory',


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
To be consistent with file naming, the package-manager-field-conforms has been prefixed with package.