### PR TITLE
jest compliance

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -73,7 +73,15 @@ describe('main', () => {
             JSON.stringify({
               packageManager: 'yarn',
               engines: { node: 'test' },
-              devDependencies: { eslint: '1.1.0' },
+              devDependencies: {
+                eslint: '1.1.0',
+                jest: '1.0.0',
+                'jest-it-up': '1.0.0',
+              },
+              scripts: {
+                test: 'test script',
+                'test:watch': 'test watch script',
+              },
             }),
           );
           await writeFile(
@@ -83,6 +91,10 @@ describe('main', () => {
           await writeFile(
             path.join(repository.directoryPath, '.nvmrc'),
             'content for .nvmrc',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, 'jest.config.js'),
+            'content for jest.config.js',
           );
         }
         const outputLogger = new FakeOutputLogger();
@@ -108,6 +120,8 @@ repo-1
   - Does the \`packageManager\` field in \`package.json\` conform? ✅
   - Does the \`engines.node\` field in \`package.json\` conform? ✅
   - Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the jest-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -115,8 +129,9 @@ repo-1
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
 - Is \`.nvmrc\` present, and does it conform? ✅
+- Is \`jest.config.js\` present, and does it conform? ✅
 
-Results:       12 passed, 0 failed, 12 total
+Results:       15 passed, 0 failed, 15 total
 Elapsed time:  0 ms
 
 
@@ -128,6 +143,8 @@ repo-2
   - Does the \`packageManager\` field in \`package.json\` conform? ✅
   - Does the \`engines.node\` field in \`package.json\` conform? ✅
   - Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the jest-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -135,8 +152,9 @@ repo-2
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
 - Is \`.nvmrc\` present, and does it conform? ✅
+- Is \`jest.config.js\` present, and does it conform? ✅
 
-Results:       12 passed, 0 failed, 12 total
+Results:       15 passed, 0 failed, 15 total
 Elapsed time:  0 ms
 
 `,
@@ -195,8 +213,10 @@ repo-1
   - \`src/\` does not exist in this project.
 - Is \`.nvmrc\` present, and does it conform? ❌
   - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
 
-Results:       0 passed, 6 failed, 6 total
+Results:       0 passed, 7 failed, 7 total
 Elapsed time:  0 ms
 
 
@@ -217,8 +237,10 @@ repo-2
   - \`src/\` does not exist in this project.
 - Is \`.nvmrc\` present, and does it conform? ❌
   - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
 
-Results:       0 passed, 6 failed, 6 total
+Results:       0 passed, 7 failed, 7 total
 Elapsed time:  0 ms
 
 `,
@@ -283,8 +305,10 @@ repo-2
   - \`src/\` does not exist in this project.
 - Is \`.nvmrc\` present, and does it conform? ❌
   - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
 
-Results:       1 passed, 5 failed, 6 total
+Results:       1 passed, 6 failed, 7 total
 Elapsed time:  0 ms
 
 `.trimStart(),
@@ -340,7 +364,15 @@ Elapsed time:  0 ms
             JSON.stringify({
               packageManager: 'yarn',
               engines: { node: 'test' },
-              devDependencies: { eslint: '1.1.0' },
+              devDependencies: {
+                eslint: '1.1.0',
+                jest: '1.0.0',
+                'jest-it-up': '1.0.0',
+              },
+              scripts: {
+                test: 'test script',
+                'test:watch': 'test watch script',
+              },
             }),
           );
           await writeFile(
@@ -350,6 +382,10 @@ Elapsed time:  0 ms
           await writeFile(
             path.join(repository.directoryPath, '.nvmrc'),
             'content for .nvmrc',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, 'jest.config.js'),
+            'content for jest.config.js',
           );
         }
         const outputLogger = new FakeOutputLogger();
@@ -375,6 +411,8 @@ repo-1
   - Does the \`packageManager\` field in \`package.json\` conform? ✅
   - Does the \`engines.node\` field in \`package.json\` conform? ✅
   - Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the jest-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -382,8 +420,9 @@ repo-1
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
 - Is \`.nvmrc\` present, and does it conform? ✅
+- Is \`jest.config.js\` present, and does it conform? ✅
 
-Results:       12 passed, 0 failed, 12 total
+Results:       15 passed, 0 failed, 15 total
 Elapsed time:  0 ms
 
 
@@ -395,6 +434,8 @@ repo-2
   - Does the \`packageManager\` field in \`package.json\` conform? ✅
   - Does the \`engines.node\` field in \`package.json\` conform? ✅
   - Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the jest-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -402,8 +443,9 @@ repo-2
   - Does the README conform by recommending the correct Yarn version to install? ✅
 - Does the \`src/\` directory exist? ✅
 - Is \`.nvmrc\` present, and does it conform? ✅
+- Is \`jest.config.js\` present, and does it conform? ✅
 
-Results:       12 passed, 0 failed, 12 total
+Results:       15 passed, 0 failed, 15 total
 Elapsed time:  0 ms
 
 `,
@@ -462,8 +504,10 @@ repo-1
   - \`src/\` does not exist in this project.
 - Is \`.nvmrc\` present, and does it conform? ❌
   - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
 
-Results:       0 passed, 6 failed, 6 total
+Results:       0 passed, 7 failed, 7 total
 Elapsed time:  0 ms
 
 
@@ -484,8 +528,10 @@ repo-2
   - \`src/\` does not exist in this project.
 - Is \`.nvmrc\` present, and does it conform? ❌
   - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
 
-Results:       0 passed, 6 failed, 6 total
+Results:       0 passed, 7 failed, 7 total
 Elapsed time:  0 ms
 
 `,
@@ -549,8 +595,10 @@ repo-2
   - \`src/\` does not exist in this project.
 - Is \`.nvmrc\` present, and does it conform? ❌
   - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
 
-Results:       1 passed, 5 failed, 6 total
+Results:       1 passed, 6 failed, 7 total
 Elapsed time:  0 ms
 
 `,

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -121,7 +121,7 @@ repo-1
   - Does the \`engines.node\` field in \`package.json\` conform? ✅
   - Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
   - Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
-  - Do the jest-related \`scripts\` in \`package.json\` conform? ✅
+  - Do the test-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -144,7 +144,7 @@ repo-2
   - Does the \`engines.node\` field in \`package.json\` conform? ✅
   - Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
   - Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
-  - Do the jest-related \`scripts\` in \`package.json\` conform? ✅
+  - Do the test-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -412,7 +412,7 @@ repo-1
   - Does the \`engines.node\` field in \`package.json\` conform? ✅
   - Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
   - Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
-  - Do the jest-related \`scripts\` in \`package.json\` conform? ✅
+  - Do the test-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -435,7 +435,7 @@ repo-2
   - Does the \`engines.node\` field in \`package.json\` conform? ✅
   - Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
   - Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
-  - Do the jest-related \`scripts\` in \`package.json\` conform? ✅
+  - Do the test-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -2,9 +2,9 @@ import allYarnModernFilesConform from './all-yarn-modern-files-conform';
 import classicYarnConfigFileAbsent from './classic-yarn-config-file-absent';
 import packageEnginesNodeFieldConforms from './package-engines-node-field-conforms';
 import packageJestDependenciesConform from './package-jest-dependencies-conform';
-import packageJestScriptsConform from './package-jest-scripts-conform';
 import packageLintDependenciesConform from './package-lint-dependencies-conform';
 import packagePackageManagerFieldConforms from './package-package-manager-field-conforms';
+import packageTestScriptsConform from './package-test-scripts-conform';
 import readmeListsCorrectYarnVersion from './readme-lists-correct-yarn-version';
 import readmeListsNodejsWebsite from './readme-recommends-node-install';
 import requireJestConfig from './require-jest-config';
@@ -27,5 +27,5 @@ export const rules = [
   packageLintDependenciesConform,
   packageJestDependenciesConform,
   requireJestConfig,
-  packageJestScriptsConform,
+  packageTestScriptsConform,
 ] as const;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,10 +1,13 @@
 import allYarnModernFilesConform from './all-yarn-modern-files-conform';
 import classicYarnConfigFileAbsent from './classic-yarn-config-file-absent';
 import packageEnginesNodeFieldConforms from './package-engines-node-field-conforms';
+import packageJestDependenciesConform from './package-jest-dependencies-conform';
+import packageJestScriptsConform from './package-jest-scripts-conform';
 import packageLintDependenciesConform from './package-lint-dependencies-conform';
 import packagePackageManagerFieldConforms from './package-package-manager-field-conforms';
 import readmeListsCorrectYarnVersion from './readme-lists-correct-yarn-version';
 import readmeListsNodejsWebsite from './readme-recommends-node-install';
+import requireJestConfig from './require-jest-config';
 import requireNvmrc from './require-nvmrc';
 import requireReadme from './require-readme';
 import requireSourceDirectory from './require-source-directory';
@@ -22,4 +25,7 @@ export const rules = [
   packageEnginesNodeFieldConforms,
   readmeListsNodejsWebsite,
   packageLintDependenciesConform,
+  packageJestDependenciesConform,
+  requireJestConfig,
+  packageJestScriptsConform,
 ] as const;

--- a/src/rules/package-engines-node-field-conforms.test.ts
+++ b/src/rules/package-engines-node-field-conforms.test.ts
@@ -18,6 +18,7 @@ describe('Rule: package-engines-node-field-conforms', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: { eslint: '1.0.0' },
+          scripts: { test: '' },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -30,6 +31,7 @@ describe('Rule: package-engines-node-field-conforms', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: { eslint: '1.0.0' },
+          scripts: { test: '' },
         }),
       );
 
@@ -58,6 +60,7 @@ describe('Rule: package-engines-node-field-conforms', () => {
           packageManager: 'a',
           engines: { node: 'test1' },
           devDependencies: { eslint: '1.0.0' },
+          scripts: { test: '' },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -70,6 +73,7 @@ describe('Rule: package-engines-node-field-conforms', () => {
           packageManager: 'a',
           engines: { node: 'test2' },
           devDependencies: { eslint: '1.0.0' },
+          scripts: { test: '' },
         }),
       );
 

--- a/src/rules/package-engines-node-field-conforms.test.ts
+++ b/src/rules/package-engines-node-field-conforms.test.ts
@@ -18,7 +18,7 @@ describe('Rule: package-engines-node-field-conforms', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: { eslint: '1.0.0' },
-          scripts: { test: '' },
+          scripts: { test: 'jest && jest-it-up' },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -31,7 +31,7 @@ describe('Rule: package-engines-node-field-conforms', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: { eslint: '1.0.0' },
-          scripts: { test: '' },
+          scripts: { test: 'jest && jest-it-up' },
         }),
       );
 
@@ -60,7 +60,7 @@ describe('Rule: package-engines-node-field-conforms', () => {
           packageManager: 'a',
           engines: { node: 'test1' },
           devDependencies: { eslint: '1.0.0' },
-          scripts: { test: '' },
+          scripts: { test: 'jest && jest-it-up' },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -73,7 +73,7 @@ describe('Rule: package-engines-node-field-conforms', () => {
           packageManager: 'a',
           engines: { node: 'test2' },
           devDependencies: { eslint: '1.0.0' },
-          scripts: { test: '' },
+          scripts: { test: 'jest && jest-it-up' },
         }),
       );
 

--- a/src/rules/package-jest-dependencies-conform.test.ts
+++ b/src/rules/package-jest-dependencies-conform.test.ts
@@ -6,7 +6,7 @@ import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
 import { fail, pass } from '../rule-helpers';
 
 describe('Rule: package-jest-dependencies-conform', () => {
-  it("passes if the jest related dependencies in the project's package.json matches the one in the template's package.json", async () => {
+  it("passes if the jest related dependencies in the project's package.json match the ones in the template's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -58,7 +58,7 @@ describe('Rule: package-jest-dependencies-conform', () => {
     });
   });
 
-  it("fails if the version of jest related dependencies in the project's package.json does not match the one in the template's package.json", async () => {
+  it("fails if the version of a jest related dependency in the project's package.json does not match the version of the same dependency in the template's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -113,7 +113,7 @@ describe('Rule: package-jest-dependencies-conform', () => {
     });
   });
 
-  it("fails if the jest related dependency exist in the template's package.json, but not in the project's package.json", async () => {
+  it("fails if the jest related dependency exists in the template's package.json, but not in the project's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',

--- a/src/rules/package-jest-dependencies-conform.test.ts
+++ b/src/rules/package-jest-dependencies-conform.test.ts
@@ -1,12 +1,12 @@
 import { writeFile } from '@metamask/utils/node';
 import path from 'path';
 
-import packageLintDependenciesConform from './package-lint-dependencies-conform';
+import packageJestDependenciesConform from './package-jest-dependencies-conform';
 import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
 import { fail, pass } from '../rule-helpers';
 
-describe('Rule: package-lint-dependencies-conform', () => {
-  it("passes if the lint related dependencies in the project's package.json matches the one in the template's package.json", async () => {
+describe('Rule: package-jest-dependencies-conform', () => {
+  it("passes if the jest related dependencies in the project's package.json matches the one in the template's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -18,16 +18,12 @@ describe('Rule: package-lint-dependencies-conform', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: {
-            '@metamask/eslint-config-foo': '1.0.0',
-            '@typescript-eslint/foo': '1.0.0',
-            eslint: '1.0.0',
-            'eslint-plugin-foo': '1.0.0',
-            'eslint-config-foo': '1.0.0',
-            prettier: '1.0.0',
-            'prettier-plugin-foo': '1.0.0',
-            'prettier-config-foo': '1.0.0',
+            jest: '1.0.0',
+            'jest-it-up': '1.0.0',
           },
-          scripts: { test: '' },
+          scripts: {
+            test: '',
+          },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -40,20 +36,16 @@ describe('Rule: package-lint-dependencies-conform', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: {
-            '@metamask/eslint-config-foo': '1.0.0',
-            '@typescript-eslint/foo': '1.0.0',
-            eslint: '1.0.0',
-            'eslint-plugin-foo': '1.0.0',
-            'eslint-config-foo': '1.0.0',
-            prettier: '1.0.0',
-            'prettier-plugin-foo': '1.0.0',
-            'prettier-config-foo': '1.0.0',
+            jest: '1.0.0',
+            'jest-it-up': '1.0.0',
           },
-          scripts: { test: '' },
+          scripts: {
+            test: '',
+          },
         }),
       );
 
-      const result = await packageLintDependenciesConform.execute({
+      const result = await packageJestDependenciesConform.execute({
         template,
         project,
         pass,
@@ -66,7 +58,7 @@ describe('Rule: package-lint-dependencies-conform', () => {
     });
   });
 
-  it("fails if the version of lint related dependencies in the project's package.json does not match the one in the template's package.json", async () => {
+  it("fails if the version of jest related dependencies in the project's package.json does not match the one in the template's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -77,8 +69,13 @@ describe('Rule: package-lint-dependencies-conform', () => {
         JSON.stringify({
           packageManager: 'a',
           engines: { node: 'test' },
-          devDependencies: { eslint: '1.1.0' },
-          scripts: { test: '' },
+          devDependencies: {
+            jest: '1.1.0',
+            'jest-it-up': '1.0.0',
+          },
+          scripts: {
+            test: '',
+          },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -90,12 +87,17 @@ describe('Rule: package-lint-dependencies-conform', () => {
         JSON.stringify({
           packageManager: 'a',
           engines: { node: 'test' },
-          devDependencies: { eslint: '1.0.0' },
-          scripts: { test: '' },
+          devDependencies: {
+            jest: '1.0.0',
+            'jest-it-up': '1.0.0',
+          },
+          scripts: {
+            test: '',
+          },
         }),
       );
 
-      const result = await packageLintDependenciesConform.execute({
+      const result = await packageJestDependenciesConform.execute({
         template,
         project,
         pass,
@@ -105,13 +107,13 @@ describe('Rule: package-lint-dependencies-conform', () => {
       expect(result).toStrictEqual({
         passed: false,
         failures: [
-          { message: '`eslint` is "1.0.0", when it should be "1.1.0".' },
+          { message: '`jest` is "1.0.0", when it should be "1.1.0".' },
         ],
       });
     });
   });
 
-  it("fails if the lint related dependency exist in the template's package.json, but not in the project's package.json", async () => {
+  it("fails if the jest related dependency exist in the template's package.json, but not in the project's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -122,8 +124,13 @@ describe('Rule: package-lint-dependencies-conform', () => {
         JSON.stringify({
           packageManager: 'a',
           engines: { node: 'test' },
-          devDependencies: { eslint: '1.1.0' },
-          scripts: { test: '' },
+          devDependencies: {
+            jest: '1.1.0',
+            'jest-it-up': '1.0.0',
+          },
+          scripts: {
+            test: '',
+          },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -135,12 +142,16 @@ describe('Rule: package-lint-dependencies-conform', () => {
         JSON.stringify({
           packageManager: 'a',
           engines: { node: 'test' },
-          devDependencies: { testlint: '1.0.0' },
-          scripts: { test: '' },
+          devDependencies: {
+            'jest-it-up': '1.0.0',
+          },
+          scripts: {
+            test: '',
+          },
         }),
       );
 
-      const result = await packageLintDependenciesConform.execute({
+      const result = await packageJestDependenciesConform.execute({
         template,
         project,
         pass,
@@ -152,14 +163,14 @@ describe('Rule: package-lint-dependencies-conform', () => {
         failures: [
           {
             message:
-              '`package.json` should list `"eslint": "1.1.0"` in `devDependencies`, but does not.',
+              '`package.json` should list `"jest": "1.1.0"` in `devDependencies`, but does not.',
           },
         ],
       });
     });
   });
 
-  it("passes if the there're no lint related dependencies in the template's package.json", async () => {
+  it("throws error if required jest related dependency in the template's package.json does not exist", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -171,9 +182,11 @@ describe('Rule: package-lint-dependencies-conform', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: {
-            '@metamask/test-config-foo': '1.0.0',
+            'jest-it-up': '1.0.0',
           },
-          scripts: { test: '' },
+          scripts: {
+            test: '',
+          },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -186,29 +199,25 @@ describe('Rule: package-lint-dependencies-conform', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: {
-            '@metamask/eslint-config-foo': '1.0.0',
-            '@typescript-eslint/foo': '1.0.0',
-            eslint: '1.0.0',
-            'eslint-plugin-foo': '1.0.0',
-            'eslint-config-foo': '1.0.0',
-            prettier: '1.0.0',
-            'prettier-plugin-foo': '1.0.0',
-            'prettier-config-foo': '1.0.0',
+            jest: '1.0.0',
+            'jest-it-up': '1.0.0',
           },
-          scripts: { test: '' },
+          scripts: {
+            test: '',
+          },
         }),
       );
 
-      const result = await packageLintDependenciesConform.execute({
-        template,
-        project,
-        pass,
-        fail,
-      });
-
-      expect(result).toStrictEqual({
-        passed: true,
-      });
+      await expect(
+        packageJestDependenciesConform.execute({
+          template,
+          project,
+          pass,
+          fail,
+        }),
+      ).rejects.toThrow(
+        'Could not find "jest" in `devDependencies` of template\'s package.json. This is not the fault of the project, but is rather a bug in a rule.',
+      );
     });
   });
 });

--- a/src/rules/package-jest-dependencies-conform.ts
+++ b/src/rules/package-jest-dependencies-conform.ts
@@ -1,0 +1,69 @@
+import { buildRule } from './build-rule';
+import { PackageManifestSchema, RuleName } from './types';
+import type { RuleExecutionFailure } from '../execute-rules';
+
+export default buildRule({
+  name: RuleName.PackageJestDependenciesConform,
+  description:
+    'Do the jest-related `devDependencies` in `package.json` conform?',
+  dependencies: [RuleName.RequireValidPackageManifest],
+  execute: async ({ project, template, pass, fail }) => {
+    const entryPath = 'package.json';
+
+    const templateManifest = await template.fs.readJsonFileAs(
+      entryPath,
+      PackageManifestSchema,
+    );
+
+    const projectManifest = await project.fs.readJsonFileAs(
+      entryPath,
+      PackageManifestSchema,
+    );
+
+    const failures: RuleExecutionFailure[] = await jestConform(
+      templateManifest.devDependencies,
+      projectManifest.devDependencies,
+    );
+
+    return failures.length === 0 ? pass() : fail(failures);
+  },
+});
+
+/**
+ * Validates whether target project has all the required jest packages with versions matching with template project.
+ *
+ * @param templateDependencies - The record of jest package name and version from template.
+ * @param projectDependencies - The record of jest package name and version from project.
+ */
+async function jestConform(
+  templateDependencies: Record<string, string>,
+  projectDependencies: Record<string, string>,
+): Promise<RuleExecutionFailure[]> {
+  const jestPackagesRequired = ['jest', 'jest-it-up'];
+  const failures: RuleExecutionFailure[] = [];
+  for (const jestPackage of jestPackagesRequired) {
+    const templatePackageVersion = templateDependencies[jestPackage];
+    if (!templatePackageVersion) {
+      throw new Error(
+        `Could not find "${jestPackage}" in \`devDependencies\` of template's package.json. This is not the fault of the project, but is rather a bug in a rule.`,
+      );
+    }
+
+    const projectPackageVersion = projectDependencies[jestPackage];
+    if (!projectPackageVersion) {
+      failures.push({
+        message: `\`package.json\` should list \`"${jestPackage}": "${templatePackageVersion}"\` in \`devDependencies\`, but does not.`,
+      });
+
+      continue;
+    }
+
+    if (projectPackageVersion !== templatePackageVersion) {
+      failures.push({
+        message: `\`${jestPackage}\` is "${projectPackageVersion}", when it should be "${templatePackageVersion}".`,
+      });
+    }
+  }
+
+  return failures;
+}

--- a/src/rules/package-jest-scripts-conform.test.ts
+++ b/src/rules/package-jest-scripts-conform.test.ts
@@ -1,12 +1,12 @@
 import { writeFile } from '@metamask/utils/node';
 import path from 'path';
 
-import packageLintDependenciesConform from './package-lint-dependencies-conform';
+import packageJestScriptsConform from './package-jest-scripts-conform';
 import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
 import { fail, pass } from '../rule-helpers';
 
-describe('Rule: package-lint-dependencies-conform', () => {
-  it("passes if the lint related dependencies in the project's package.json matches the one in the template's package.json", async () => {
+describe('Rule: package-jest-scripts-conform', () => {
+  it("passes if the jest related scripts in the project's package.json matches the one in the template's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -18,16 +18,13 @@ describe('Rule: package-lint-dependencies-conform', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: {
-            '@metamask/eslint-config-foo': '1.0.0',
-            '@typescript-eslint/foo': '1.0.0',
-            eslint: '1.0.0',
-            'eslint-plugin-foo': '1.0.0',
-            'eslint-config-foo': '1.0.0',
-            prettier: '1.0.0',
-            'prettier-plugin-foo': '1.0.0',
-            'prettier-config-foo': '1.0.0',
+            jest: '1.0.0',
+            'jest-it-up': '1.0.0',
           },
-          scripts: { test: '' },
+          scripts: {
+            test: 'test script',
+            'test:watch': 'test watch script',
+          },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -40,20 +37,17 @@ describe('Rule: package-lint-dependencies-conform', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: {
-            '@metamask/eslint-config-foo': '1.0.0',
-            '@typescript-eslint/foo': '1.0.0',
-            eslint: '1.0.0',
-            'eslint-plugin-foo': '1.0.0',
-            'eslint-config-foo': '1.0.0',
-            prettier: '1.0.0',
-            'prettier-plugin-foo': '1.0.0',
-            'prettier-config-foo': '1.0.0',
+            jest: '1.0.0',
+            'jest-it-up': '1.0.0',
           },
-          scripts: { test: '' },
+          scripts: {
+            test: 'test script',
+            'test:watch': 'test watch script',
+          },
         }),
       );
 
-      const result = await packageLintDependenciesConform.execute({
+      const result = await packageJestScriptsConform.execute({
         template,
         project,
         pass,
@@ -66,7 +60,7 @@ describe('Rule: package-lint-dependencies-conform', () => {
     });
   });
 
-  it("fails if the version of lint related dependencies in the project's package.json does not match the one in the template's package.json", async () => {
+  it("fails if the script of jest related in the project's package.json does not match the one in the template's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -77,8 +71,11 @@ describe('Rule: package-lint-dependencies-conform', () => {
         JSON.stringify({
           packageManager: 'a',
           engines: { node: 'test' },
-          devDependencies: { eslint: '1.1.0' },
-          scripts: { test: '' },
+          devDependencies: { jest: '1.1.0' },
+          scripts: {
+            test: 'test script',
+            'test:watch': 'test watch script',
+          },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -90,12 +87,15 @@ describe('Rule: package-lint-dependencies-conform', () => {
         JSON.stringify({
           packageManager: 'a',
           engines: { node: 'test' },
-          devDependencies: { eslint: '1.0.0' },
-          scripts: { test: '' },
+          devDependencies: { jest: '1.0.0' },
+          scripts: {
+            test: 'test',
+            'test:watch': 'test watch script',
+          },
         }),
       );
 
-      const result = await packageLintDependenciesConform.execute({
+      const result = await packageJestScriptsConform.execute({
         template,
         project,
         pass,
@@ -105,13 +105,13 @@ describe('Rule: package-lint-dependencies-conform', () => {
       expect(result).toStrictEqual({
         passed: false,
         failures: [
-          { message: '`eslint` is "1.0.0", when it should be "1.1.0".' },
+          { message: '`test` is "test", when it should be "test script".' },
         ],
       });
     });
   });
 
-  it("fails if the lint related dependency exist in the template's package.json, but not in the project's package.json", async () => {
+  it("fails if the jest related script exist in the template's package.json, but not in the project's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -122,8 +122,11 @@ describe('Rule: package-lint-dependencies-conform', () => {
         JSON.stringify({
           packageManager: 'a',
           engines: { node: 'test' },
-          devDependencies: { eslint: '1.1.0' },
-          scripts: { test: '' },
+          devDependencies: { jest: '1.1.0' },
+          scripts: {
+            test: 'test script',
+            'test:watch': 'test watch script',
+          },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -135,12 +138,14 @@ describe('Rule: package-lint-dependencies-conform', () => {
         JSON.stringify({
           packageManager: 'a',
           engines: { node: 'test' },
-          devDependencies: { testlint: '1.0.0' },
-          scripts: { test: '' },
+          devDependencies: { test: '1.0.0' },
+          scripts: {
+            'test:watch': 'test watch script',
+          },
         }),
       );
 
-      const result = await packageLintDependenciesConform.execute({
+      const result = await packageJestScriptsConform.execute({
         template,
         project,
         pass,
@@ -152,14 +157,14 @@ describe('Rule: package-lint-dependencies-conform', () => {
         failures: [
           {
             message:
-              '`package.json` should list `"eslint": "1.1.0"` in `devDependencies`, but does not.',
+              '`package.json` should list `"test": "test script"` in `scripts`, but does not.',
           },
         ],
       });
     });
   });
 
-  it("passes if the there're no lint related dependencies in the template's package.json", async () => {
+  it("throws error if there're no jest related scripts in the template's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -171,9 +176,11 @@ describe('Rule: package-lint-dependencies-conform', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: {
-            '@metamask/test-config-foo': '1.0.0',
+            foo: '1.0.0',
           },
-          scripts: { test: '' },
+          scripts: {
+            'test:watch': 'test watch script',
+          },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -186,29 +193,26 @@ describe('Rule: package-lint-dependencies-conform', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: {
-            '@metamask/eslint-config-foo': '1.0.0',
-            '@typescript-eslint/foo': '1.0.0',
-            eslint: '1.0.0',
-            'eslint-plugin-foo': '1.0.0',
-            'eslint-config-foo': '1.0.0',
-            prettier: '1.0.0',
-            'prettier-plugin-foo': '1.0.0',
-            'prettier-config-foo': '1.0.0',
+            jest: '1.0.0',
+            'jest-it-up': '1.0.0',
           },
-          scripts: { test: '' },
+          scripts: {
+            test: 'test scripts',
+            'test:watch': 'test watch scripts',
+          },
         }),
       );
 
-      const result = await packageLintDependenciesConform.execute({
-        template,
-        project,
-        pass,
-        fail,
-      });
-
-      expect(result).toStrictEqual({
-        passed: true,
-      });
+      await expect(
+        packageJestScriptsConform.execute({
+          template,
+          project,
+          pass,
+          fail,
+        }),
+      ).rejects.toThrow(
+        'Could not find "test" in `scripts` of template\'s package.json. This is not the fault of the project, but is rather a bug in a rule.',
+      );
     });
   });
 });

--- a/src/rules/package-jest-scripts-conform.ts
+++ b/src/rules/package-jest-scripts-conform.ts
@@ -1,0 +1,68 @@
+import { buildRule } from './build-rule';
+import { PackageManifestSchema, RuleName } from './types';
+import type { RuleExecutionFailure } from '../execute-rules';
+
+export default buildRule({
+  name: RuleName.PackageJestScriptsConform,
+  description: 'Do the jest-related `scripts` in `package.json` conform?',
+  dependencies: [RuleName.RequireValidPackageManifest],
+  execute: async ({ project, template, pass, fail }) => {
+    const entryPath = 'package.json';
+
+    const templateManifest = await template.fs.readJsonFileAs(
+      entryPath,
+      PackageManifestSchema,
+    );
+
+    const projectManifest = await project.fs.readJsonFileAs(
+      entryPath,
+      PackageManifestSchema,
+    );
+
+    const failures: RuleExecutionFailure[] = await jestConform(
+      templateManifest.scripts,
+      projectManifest.scripts,
+    );
+
+    return failures.length === 0 ? pass() : fail(failures);
+  },
+});
+
+/**
+ * Validates whether target project has all the required jest scripts matching with template project.
+ *
+ * @param templateScripts - The record of key and value from template scripts.
+ * @param projectScripts - The record of key and value from project scripts.
+ */
+async function jestConform(
+  templateScripts: Record<string, string>,
+  projectScripts: Record<string, string>,
+): Promise<RuleExecutionFailure[]> {
+  const jestScriptsRequired = ['test', 'test:watch'];
+  const failures: RuleExecutionFailure[] = [];
+  for (const jestScriptKey of jestScriptsRequired) {
+    const templateScript = templateScripts[jestScriptKey];
+    if (!templateScript) {
+      throw new Error(
+        `Could not find "${jestScriptKey}" in \`scripts\` of template's package.json. This is not the fault of the project, but is rather a bug in a rule.`,
+      );
+    }
+
+    const projectScript = projectScripts[jestScriptKey];
+    if (!projectScript) {
+      failures.push({
+        message: `\`package.json\` should list \`"${jestScriptKey}": "${templateScript}"\` in \`scripts\`, but does not.`,
+      });
+
+      continue;
+    }
+
+    if (projectScript !== templateScript) {
+      failures.push({
+        message: `\`${jestScriptKey}\` is "${projectScript}", when it should be "${templateScript}".`,
+      });
+    }
+  }
+
+  return failures;
+}

--- a/src/rules/package-package-manager-field-conforms.test.ts
+++ b/src/rules/package-package-manager-field-conforms.test.ts
@@ -18,6 +18,7 @@ describe('Rule: package-manager-field-conforms', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: { eslint: '1.0.0' },
+          scripts: { test: '' },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -30,6 +31,7 @@ describe('Rule: package-manager-field-conforms', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: { eslint: '1.0.0' },
+          scripts: { test: '' },
         }),
       );
 
@@ -58,6 +60,7 @@ describe('Rule: package-manager-field-conforms', () => {
           packageManager: 'a',
           engines: { node: 'test' },
           devDependencies: { eslint: '1.0.0' },
+          scripts: { test: '' },
         }),
       );
       const project = buildMetaMaskRepository({
@@ -70,6 +73,7 @@ describe('Rule: package-manager-field-conforms', () => {
           packageManager: 'b',
           engines: { node: 'test' },
           devDependencies: { eslint: '1.0.0' },
+          scripts: { test: '' },
         }),
       );
 

--- a/src/rules/package-test-scripts-conform.test.ts
+++ b/src/rules/package-test-scripts-conform.test.ts
@@ -1,12 +1,12 @@
 import { writeFile } from '@metamask/utils/node';
 import path from 'path';
 
-import packageJestScriptsConform from './package-jest-scripts-conform';
+import packageTestScriptsConform from './package-test-scripts-conform';
 import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
 import { fail, pass } from '../rule-helpers';
 
-describe('Rule: package-jest-scripts-conform', () => {
-  it("passes if the jest related scripts in the project's package.json matches the one in the template's package.json", async () => {
+describe('Rule: package-test-scripts-conform', () => {
+  it("passes if the test related scripts in the project's package.json match the ones in the template's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -47,7 +47,7 @@ describe('Rule: package-jest-scripts-conform', () => {
         }),
       );
 
-      const result = await packageJestScriptsConform.execute({
+      const result = await packageTestScriptsConform.execute({
         template,
         project,
         pass,
@@ -60,7 +60,7 @@ describe('Rule: package-jest-scripts-conform', () => {
     });
   });
 
-  it("fails if the script of jest related in the project's package.json does not match the one in the template's package.json", async () => {
+  it("fails if a test related script in the project's package.json does not match the same one in the template's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -95,7 +95,7 @@ describe('Rule: package-jest-scripts-conform', () => {
         }),
       );
 
-      const result = await packageJestScriptsConform.execute({
+      const result = await packageTestScriptsConform.execute({
         template,
         project,
         pass,
@@ -111,7 +111,7 @@ describe('Rule: package-jest-scripts-conform', () => {
     });
   });
 
-  it("fails if the jest related script exist in the template's package.json, but not in the project's package.json", async () => {
+  it("fails if a test related script exists in the template's package.json, but not in the project's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -145,7 +145,7 @@ describe('Rule: package-jest-scripts-conform', () => {
         }),
       );
 
-      const result = await packageJestScriptsConform.execute({
+      const result = await packageTestScriptsConform.execute({
         template,
         project,
         pass,
@@ -164,7 +164,7 @@ describe('Rule: package-jest-scripts-conform', () => {
     });
   });
 
-  it("throws error if there're no jest related scripts in the template's package.json", async () => {
+  it("throws error if there are no test related scripts in the template's package.json", async () => {
     await withinSandbox(async (sandbox) => {
       const template = buildMetaMaskRepository({
         shortname: 'template',
@@ -204,7 +204,7 @@ describe('Rule: package-jest-scripts-conform', () => {
       );
 
       await expect(
-        packageJestScriptsConform.execute({
+        packageTestScriptsConform.execute({
           template,
           project,
           pass,

--- a/src/rules/package-test-scripts-conform.ts
+++ b/src/rules/package-test-scripts-conform.ts
@@ -3,8 +3,8 @@ import { PackageManifestSchema, RuleName } from './types';
 import type { RuleExecutionFailure } from '../execute-rules';
 
 export default buildRule({
-  name: RuleName.PackageJestScriptsConform,
-  description: 'Do the jest-related `scripts` in `package.json` conform?',
+  name: RuleName.PackageTestScriptsConform,
+  description: 'Do the test-related `scripts` in `package.json` conform?',
   dependencies: [RuleName.RequireValidPackageManifest],
   execute: async ({ project, template, pass, fail }) => {
     const entryPath = 'package.json';
@@ -19,7 +19,7 @@ export default buildRule({
       PackageManifestSchema,
     );
 
-    const failures: RuleExecutionFailure[] = await jestConform(
+    const failures: RuleExecutionFailure[] = await testConform(
       templateManifest.scripts,
       projectManifest.scripts,
     );
@@ -29,29 +29,29 @@ export default buildRule({
 });
 
 /**
- * Validates whether target project has all the required jest scripts matching with template project.
+ * Validates whether target project has all the required test scripts matching with template project.
  *
  * @param templateScripts - The record of key and value from template scripts.
  * @param projectScripts - The record of key and value from project scripts.
  */
-async function jestConform(
+async function testConform(
   templateScripts: Record<string, string>,
   projectScripts: Record<string, string>,
 ): Promise<RuleExecutionFailure[]> {
-  const jestScriptsRequired = ['test', 'test:watch'];
+  const testScriptsRequired = ['test', 'test:watch'];
   const failures: RuleExecutionFailure[] = [];
-  for (const jestScriptKey of jestScriptsRequired) {
-    const templateScript = templateScripts[jestScriptKey];
+  for (const testScriptKey of testScriptsRequired) {
+    const templateScript = templateScripts[testScriptKey];
     if (!templateScript) {
       throw new Error(
-        `Could not find "${jestScriptKey}" in \`scripts\` of template's package.json. This is not the fault of the project, but is rather a bug in a rule.`,
+        `Could not find "${testScriptKey}" in \`scripts\` of template's package.json. This is not the fault of the project, but is rather a bug in a rule.`,
       );
     }
 
-    const projectScript = projectScripts[jestScriptKey];
+    const projectScript = projectScripts[testScriptKey];
     if (!projectScript) {
       failures.push({
-        message: `\`package.json\` should list \`"${jestScriptKey}": "${templateScript}"\` in \`scripts\`, but does not.`,
+        message: `\`package.json\` should list \`"${testScriptKey}": "${templateScript}"\` in \`scripts\`, but does not.`,
       });
 
       continue;
@@ -59,7 +59,7 @@ async function jestConform(
 
     if (projectScript !== templateScript) {
       failures.push({
-        message: `\`${jestScriptKey}\` is "${projectScript}", when it should be "${templateScript}".`,
+        message: `\`${testScriptKey}\` is "${projectScript}", when it should be "${templateScript}".`,
       });
     }
   }

--- a/src/rules/package-test-scripts-conform.ts
+++ b/src/rules/package-test-scripts-conform.ts
@@ -19,7 +19,7 @@ export default buildRule({
       PackageManifestSchema,
     );
 
-    const failures: RuleExecutionFailure[] = await testConform(
+    const failures: RuleExecutionFailure[] = await testScriptsConform(
       templateManifest.scripts,
       projectManifest.scripts,
     );
@@ -34,7 +34,7 @@ export default buildRule({
  * @param templateScripts - The record of key and value from template scripts.
  * @param projectScripts - The record of key and value from project scripts.
  */
-async function testConform(
+async function testScriptsConform(
   templateScripts: Record<string, string>,
   projectScripts: Record<string, string>,
 ): Promise<RuleExecutionFailure[]> {

--- a/src/rules/require-jest-config.ts
+++ b/src/rules/require-jest-config.ts
@@ -1,0 +1,12 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { fileConforms } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.RequireJestConfig,
+  description: 'Is `jest.config.js` present, and does it conform?',
+  dependencies: [],
+  execute: async (ruleExecutionArguments) => {
+    return await fileConforms('jest.config.js', ruleExecutionArguments);
+  },
+});

--- a/src/rules/require-valid-package-manifest.test.ts
+++ b/src/rules/require-valid-package-manifest.test.ts
@@ -18,6 +18,7 @@ describe('Rule: require-package-manifest', () => {
           packageManager: 'foo',
           engines: { node: 'test' },
           devDependencies: { eslint: '1.0.0' },
+          scripts: { test: 'test script' },
         }),
       );
 
@@ -82,7 +83,7 @@ describe('Rule: require-package-manifest', () => {
         failures: [
           {
             message:
-              'Invalid `package.json`: Missing `packageManager`; Missing `engines`; Missing `devDependencies`.',
+              'Invalid `package.json`: Missing `packageManager`; Missing `engines`; Missing `scripts`; Missing `devDependencies`.',
           },
         ],
       });

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -15,6 +15,9 @@ export enum RuleName {
   PackageEnginesNodeFieldConforms = 'package-engines-node-field-conforms',
   ReadmeRecommendsNodeInstall = 'readme-recommends-node-install',
   PackageLintDependenciesConform = 'package-lint-dependencies-conform',
+  PackageJestDependenciesConform = 'package-jest-dependencies-conform',
+  RequireJestConfig = 'require-jest-config',
+  PackageJestScriptsConform = 'package-jest-scripts-conform',
 }
 
 export const PackageManifestSchema = type({
@@ -22,5 +25,6 @@ export const PackageManifestSchema = type({
   engines: type({
     node: string(),
   }),
+  scripts: record(string(), string()),
   devDependencies: record(string(), string()),
 });

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -17,7 +17,7 @@ export enum RuleName {
   PackageLintDependenciesConform = 'package-lint-dependencies-conform',
   PackageJestDependenciesConform = 'package-jest-dependencies-conform',
   RequireJestConfig = 'require-jest-config',
-  PackageJestScriptsConform = 'package-jest-scripts-conform',
+  PackageTestScriptsConform = 'package-test-scripts-conform',
 }
 
 export const PackageManifestSchema = type({


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
We want to make sure that for a given project:
* The project contains jest and jest-it-up as dev dependencies, and the versions match the same dev dependencies as in the module template
* The project contains a jest.config.js, and the content of this file matches the same as in the module template
* The project has test and test:watch package scripts, and the values of these match the same package scripts as in the module template

Fixes #10 
