### PR TITLE
typedoc compliance

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -83,12 +83,14 @@ describe('main', () => {
                 'ts-node': '1.0.0',
                 tsup: '1.0.0',
                 typescript: '1.0.0',
+                typedoc: '1.0.0',
               },
               scripts: {
                 test: 'test script',
                 'test:watch': 'test watch script',
                 build: 'test build',
                 'build:types': 'test build types',
+                'build:docs': 'test build docs',
               },
             }),
           );
@@ -115,6 +117,10 @@ describe('main', () => {
           await writeFile(
             path.join(repository.directoryPath, 'tsup.config.ts'),
             'content for tsup.config.ts',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, 'typedoc.json'),
+            'content for typedoc.json',
           );
         }
         const outputLogger = new FakeOutputLogger();
@@ -150,6 +156,8 @@ repo-1
   - Does the \`types\` field in \`package.json\` conform? ✅
   - Does the \`files\` field in \`package.json\` conform? ✅
   - Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
+  - Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -161,8 +169,9 @@ repo-1
 - Is \`tsconfig.json\` present, and does it conform? ✅
 - Is \`tsconfig.build.json\` present, and does it conform? ✅
 - Is \`tsup.config.ts\` present, and does it conform? ✅
+- Is \`typedoc.json\` present, and does it conform? ✅
 
-Results:       26 passed, 0 failed, 26 total
+Results:       29 passed, 0 failed, 29 total
 Elapsed time:  0 ms
 
 
@@ -184,6 +193,8 @@ repo-2
   - Does the \`types\` field in \`package.json\` conform? ✅
   - Does the \`files\` field in \`package.json\` conform? ✅
   - Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
+  - Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -195,8 +206,9 @@ repo-2
 - Is \`tsconfig.json\` present, and does it conform? ✅
 - Is \`tsconfig.build.json\` present, and does it conform? ✅
 - Is \`tsup.config.ts\` present, and does it conform? ✅
+- Is \`typedoc.json\` present, and does it conform? ✅
 
-Results:       26 passed, 0 failed, 26 total
+Results:       29 passed, 0 failed, 29 total
 Elapsed time:  0 ms
 
 `,
@@ -263,8 +275,10 @@ repo-1
   - \`tsconfig.build.json\` does not exist in this project.
 - Is \`tsup.config.ts\` present, and does it conform? ❌
   - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
 
-Results:       0 passed, 10 failed, 10 total
+Results:       0 passed, 11 failed, 11 total
 Elapsed time:  0 ms
 
 
@@ -293,8 +307,10 @@ repo-2
   - \`tsconfig.build.json\` does not exist in this project.
 - Is \`tsup.config.ts\` present, and does it conform? ❌
   - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
 
-Results:       0 passed, 10 failed, 10 total
+Results:       0 passed, 11 failed, 11 total
 Elapsed time:  0 ms
 
 `,
@@ -367,8 +383,10 @@ repo-2
   - \`tsconfig.build.json\` does not exist in this project.
 - Is \`tsup.config.ts\` present, and does it conform? ❌
   - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
 
-Results:       1 passed, 9 failed, 10 total
+Results:       1 passed, 10 failed, 11 total
 Elapsed time:  0 ms
 
 `.trimStart(),
@@ -430,12 +448,14 @@ Elapsed time:  0 ms
                 'ts-node': '1.0.0',
                 tsup: '1.0.0',
                 typescript: '1.0.0',
+                typedoc: '1.0.0',
               },
               scripts: {
                 test: 'test script',
                 'test:watch': 'test watch script',
                 build: 'test build',
                 'build:types': 'test build types',
+                'build:docs': 'test build docs',
               },
             }),
           );
@@ -462,6 +482,10 @@ Elapsed time:  0 ms
           await writeFile(
             path.join(repository.directoryPath, 'tsup.config.ts'),
             'content for tsup.config.ts',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, 'typedoc.json'),
+            'content for typedoc.json',
           );
         }
         const outputLogger = new FakeOutputLogger();
@@ -497,6 +521,8 @@ repo-1
   - Does the \`types\` field in \`package.json\` conform? ✅
   - Does the \`files\` field in \`package.json\` conform? ✅
   - Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
+  - Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -508,8 +534,9 @@ repo-1
 - Is \`tsconfig.json\` present, and does it conform? ✅
 - Is \`tsconfig.build.json\` present, and does it conform? ✅
 - Is \`tsup.config.ts\` present, and does it conform? ✅
+- Is \`typedoc.json\` present, and does it conform? ✅
 
-Results:       26 passed, 0 failed, 26 total
+Results:       29 passed, 0 failed, 29 total
 Elapsed time:  0 ms
 
 
@@ -531,6 +558,8 @@ repo-2
   - Does the \`types\` field in \`package.json\` conform? ✅
   - Does the \`files\` field in \`package.json\` conform? ✅
   - Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
+  - Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -542,8 +571,9 @@ repo-2
 - Is \`tsconfig.json\` present, and does it conform? ✅
 - Is \`tsconfig.build.json\` present, and does it conform? ✅
 - Is \`tsup.config.ts\` present, and does it conform? ✅
+- Is \`typedoc.json\` present, and does it conform? ✅
 
-Results:       26 passed, 0 failed, 26 total
+Results:       29 passed, 0 failed, 29 total
 Elapsed time:  0 ms
 
 `,
@@ -610,8 +640,10 @@ repo-1
   - \`tsconfig.build.json\` does not exist in this project.
 - Is \`tsup.config.ts\` present, and does it conform? ❌
   - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
 
-Results:       0 passed, 10 failed, 10 total
+Results:       0 passed, 11 failed, 11 total
 Elapsed time:  0 ms
 
 
@@ -640,8 +672,10 @@ repo-2
   - \`tsconfig.build.json\` does not exist in this project.
 - Is \`tsup.config.ts\` present, and does it conform? ❌
   - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
 
-Results:       0 passed, 10 failed, 10 total
+Results:       0 passed, 11 failed, 11 total
 Elapsed time:  0 ms
 
 `,
@@ -713,8 +747,10 @@ repo-2
   - \`tsconfig.build.json\` does not exist in this project.
 - Is \`tsup.config.ts\` present, and does it conform? ❌
   - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
 
-Results:       1 passed, 9 failed, 10 total
+Results:       1 passed, 10 failed, 11 total
 Elapsed time:  0 ms
 
 `,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -10,6 +10,8 @@ import packageMainFieldConforms from './package-main-field-conforms';
 import packageModuleFieldConforms from './package-module-field-conforms';
 import packagePackageManagerFieldConforms from './package-package-manager-field-conforms';
 import packageTestScriptsConform from './package-test-scripts-conform';
+import packageTypedocDevDependenciesConform from './package-typedoc-dev-dependencies-conform';
+import packageTypedocScriptsConform from './package-typedoc-scripts-conform';
 import packageTypesFieldConforms from './package-types-field-conforms';
 import packageTypescriptDevDependenciesConform from './package-typescript-dev-dependencies-conform';
 import packageTypescriptScriptsConform from './package-typescript-scripts-conform';
@@ -22,6 +24,7 @@ import requireSourceDirectory from './require-source-directory';
 import requireTsconfig from './require-tsconfig';
 import requireTsconfigBuild from './require-tsconfig-build';
 import requireTsupConfig from './require-tsup-config';
+import requireTypedoc from './require-typedoc';
 import requireValidPackageManifest from './require-valid-package-manifest';
 
 export const rules = [
@@ -50,4 +53,7 @@ export const rules = [
   packageTypesFieldConforms,
   packageFilesFieldConforms,
   packageLavamoatTsupConforms,
+  packageTypedocDevDependenciesConform,
+  packageTypedocScriptsConform,
+  requireTypedoc,
 ] as const;

--- a/src/rules/package-typedoc-dev-dependencies-conform.test.ts
+++ b/src/rules/package-typedoc-dev-dependencies-conform.test.ts
@@ -1,0 +1,178 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import packageTypedocDevDependenciesConform from './package-typedoc-dev-dependencies-conform';
+import {
+  buildMetaMaskRepository,
+  buildPackageManifestMock,
+  withinSandbox,
+} from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: package-typedoc-dev-dependencies-conform', () => {
+  it('passes if the typedoc related devDependencies of template exist in project with the version matching', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            typedoc: '1.0.0',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            typedoc: '1.0.0',
+          },
+        }),
+      );
+      const result = await packageTypedocDevDependenciesConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({ passed: true });
+    });
+  });
+
+  it('fails if the typedoc related devDependencies of template exist in project, but its version does not match', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            typedoc: '1.0.0',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            typedoc: '0.0.1',
+          },
+        }),
+      );
+      const result = await packageTypedocDevDependenciesConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message:
+              "`devDependencies.[typedoc]` is '0.0.1', when it should be '1.0.0'.",
+          },
+        ],
+      });
+    });
+  });
+
+  it('fails if the typedoc related devDependencies does not exist in project', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            typedoc: '1.0.0',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            test: '1.0.0',
+          },
+        }),
+      );
+      const result = await packageTypedocDevDependenciesConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message:
+              "`package.json` should list `'devDependencies.[typedoc]': '1.0.0'`, but does not.",
+          },
+        ],
+      });
+    });
+  });
+
+  it('throws error if the typedoc related devDependencies does not exist in the template', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            test: '1.0.0',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            typedoc: '1.0.0',
+          },
+        }),
+      );
+      await expect(
+        packageTypedocDevDependenciesConform.execute({
+          template,
+          project,
+          pass,
+          fail,
+        }),
+      ).rejects.toThrow(
+        'Could not find `devDependencies.[typedoc]` in reference `package.json`. This is not the fault of the target `package.json`, but is rather a bug in a rule.',
+      );
+    });
+  });
+});

--- a/src/rules/package-typedoc-dev-dependencies-conform.ts
+++ b/src/rules/package-typedoc-dev-dependencies-conform.ts
@@ -1,0 +1,16 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { packageManifestPropertiesConform } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.PackageTypedocDependenciesConform,
+  description:
+    'Do the typedoc-related `devDependencies` in `package.json` conform?',
+  dependencies: [RuleName.RequireValidPackageManifest],
+  execute: async (ruleExecutionArguments) => {
+    return packageManifestPropertiesConform(
+      ['devDependencies.[typedoc]'],
+      ruleExecutionArguments,
+    );
+  },
+});

--- a/src/rules/package-typedoc-scripts-conform.test.ts
+++ b/src/rules/package-typedoc-scripts-conform.test.ts
@@ -1,0 +1,162 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import packageTypedocScriptsConform from './package-typedoc-scripts-conform';
+import {
+  buildMetaMaskRepository,
+  buildPackageManifestMock,
+  withinSandbox,
+} from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: package-typedoc-scripts-conform', () => {
+  it('passes if the project and template have the build:docs in scripts and matches', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: { 'build:docs': 'test build docs' },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: { 'build:docs': 'test build docs' },
+        }),
+      );
+      const result = await packageTypedocScriptsConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({ passed: true });
+    });
+  });
+
+  it('fails if the project and template have the build:docs in scripts, but does not match', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: { 'build:docs': 'test build docs' },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: { 'build:docs': 'test' },
+        }),
+      );
+      const result = await packageTypedocScriptsConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message:
+              "`scripts.[build:docs]` is 'test', when it should be 'test build docs'.",
+          },
+        ],
+      });
+    });
+  });
+
+  it('fails if the project does not have the build:docs in scripts', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: { 'build:docs': 'test build docs' },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: { 'test:docs': 'test docs' },
+        }),
+      );
+      const result = await packageTypedocScriptsConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message:
+              "`package.json` should list `'scripts.[build:docs]': 'test build docs'`, but does not.",
+          },
+        ],
+      });
+    });
+  });
+
+  it("throws error if build:docs does not exist in template's scripts", async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: { 'test:docs': 'test docs' },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: { 'build:docs': 'test build docs' },
+        }),
+      );
+      await expect(
+        packageTypedocScriptsConform.execute({
+          template,
+          project,
+          pass,
+          fail,
+        }),
+      ).rejects.toThrow(
+        'Could not find `scripts.[build:docs]` in reference `package.json`. This is not the fault of the target `package.json`, but is rather a bug in a rule.',
+      );
+    });
+  });
+});

--- a/src/rules/package-typedoc-scripts-conform.ts
+++ b/src/rules/package-typedoc-scripts-conform.ts
@@ -1,0 +1,15 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { packageManifestPropertiesConform } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.PackageTypedocScriptsConform,
+  description: 'Do the typedoc-related `scripts` in `package.json` conform?',
+  dependencies: [RuleName.RequireValidPackageManifest],
+  execute: async (ruleExecutionArguments) => {
+    return await packageManifestPropertiesConform(
+      ['scripts.[build:docs]'],
+      ruleExecutionArguments,
+    );
+  },
+});

--- a/src/rules/require-typedoc.test.ts
+++ b/src/rules/require-typedoc.test.ts
@@ -1,0 +1,73 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import requireTypedoc from './require-typedoc';
+import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: require-typedoc', () => {
+  it('passes if the project has a typedoc.json', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'typedoc.json'),
+        'contents of typedoc',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'typedoc.json'),
+        'contents of typedoc',
+      );
+
+      const result = await requireTypedoc.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: true,
+      });
+    });
+  });
+
+  it('fails with failure message when typedoc.json does not exist', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'typedoc.json'),
+        'contents of typedoc.json',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+
+      const result = await requireTypedoc.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message: '`typedoc.json` does not exist in this project.',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/rules/require-typedoc.ts
+++ b/src/rules/require-typedoc.ts
@@ -1,0 +1,12 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { fileConforms } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.RequireTypedoc,
+  description: 'Is `typedoc.json` present, and does it conform?',
+  dependencies: [],
+  execute: async (ruleExecutionArguments) => {
+    return await fileConforms('typedoc.json', ruleExecutionArguments);
+  },
+});

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -29,6 +29,9 @@ export enum RuleName {
   PackageTypesFieldConforms = 'package-types-field-conforms',
   PackageFilesFieldConforms = 'package-files-field-conforms',
   PackageLavamoatTsupConforms = 'package-lavamoat-tsup-conforms',
+  PackageTypedocDependenciesConform = 'package-typedoc-dependencies-conform',
+  RequireTypedoc = 'require-typedoc',
+  PackageTypedocScriptsConform = 'package-typedoc-scripts-conform',
 }
 
 export const PackageManifestSchema = type({


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
We want to make sure that for a given project:
* The project contains typedoc as a dev dependency, and the versions match the same dev dependencies as in the module template.
* The project contains a typedoc.json, and the content of this file matches the same as in the module template.
* The project contains the same build:docs package script as in the module template.

Fixes [#47](https://github.com/MetaMask/module-lint/issues/47)