### PR TITLE
trimming the content removed in readFile

### DIFF
--- a/src/repository-filesystem.test.ts
+++ b/src/repository-filesystem.test.ts
@@ -36,22 +36,6 @@ describe('RepositoryFilesystem', () => {
           '/some/directory/some.file',
         );
       });
-
-      it('returns the content of the file, with extra whitespace trimmed', async () => {
-        await withinSandbox(async ({ directoryPath: sandboxDirectoryPath }) => {
-          await writeFile(
-            path.join(sandboxDirectoryPath, 'some.file'),
-            '  some content  ',
-          );
-          const repositoryFilesystem = new RepositoryFilesystem(
-            sandboxDirectoryPath,
-          );
-
-          const content = await repositoryFilesystem.readFile('some.file');
-
-          expect(content).toBe('some content');
-        });
-      });
     });
 
     describe('if the file has already been read', () => {
@@ -65,23 +49,6 @@ describe('RepositoryFilesystem', () => {
         await repositoryFilesystem.readFile('/some/file');
 
         expect(utilsMock.readFile).toHaveBeenCalledTimes(1);
-      });
-
-      it('returns the content of the file, with extra whitespace trimmed', async () => {
-        await withinSandbox(async ({ directoryPath: sandboxDirectoryPath }) => {
-          await writeFile(
-            path.join(sandboxDirectoryPath, 'some.file'),
-            '  some content  ',
-          );
-          const repositoryFilesystem = new RepositoryFilesystem(
-            sandboxDirectoryPath,
-          );
-          await repositoryFilesystem.readFile('some.file');
-
-          const content = await repositoryFilesystem.readFile('some.file');
-
-          expect(content).toBe('some content');
-        });
       });
     });
   });

--- a/src/repository-filesystem.ts
+++ b/src/repository-filesystem.ts
@@ -48,7 +48,7 @@ export class RepositoryFilesystem {
   async readFile(filePath: string): Promise<string> {
     const cachedContent = this.#fileContents[filePath];
     const content =
-      cachedContent ?? (await readFile(this.#getFullPath(filePath))).trim();
+      cachedContent ?? (await readFile(this.#getFullPath(filePath)));
     this.#fileContents[filePath] = content;
     return content;
   }


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
I was working on the changelog.md file validation and found that `validateChangelog` was failing with one character less! When I traced the reason, I found that there's a trim on the content of the file in `readFile` function. Once I removed trim, it worked fine.

I think, when we override the functionality, in this case `readFile` overrides functionality from `metamask/utils` which uses `fs`. We need to add an additional parameters which can modify the original behaviour, so that consumer is aware and can utilise according to the need.
