### PR TITLE
checks for .editorconfig .gitattributes .gitignore

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -21,6 +21,17 @@ jest.mock('execa');
 
 const execaMock = jest.mocked<PrimaryExecaFunction>(execa);
 
+const wellFormattedChangelog = `# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/module-lint/
+`;
+
 describe('main', () => {
   beforeEach(() => {
     fakeDateOnly();
@@ -84,6 +95,7 @@ describe('main', () => {
                 tsup: '1.0.0',
                 typescript: '1.0.0',
                 typedoc: '1.0.0',
+                '@metamask/auto-changelog': '1.0.0',
               },
               scripts: {
                 test: 'test script',
@@ -91,6 +103,11 @@ describe('main', () => {
                 build: 'test build',
                 'build:types': 'test build types',
                 'build:docs': 'test build docs',
+                'lint:changelog': 'test changelog',
+                lint: 'test build types && yarn lint:changelog',
+              },
+              repository: {
+                url: 'https://github.com/MetaMask/module-lint.git',
               },
             }),
           );
@@ -121,6 +138,10 @@ describe('main', () => {
           await writeFile(
             path.join(repository.directoryPath, 'typedoc.json'),
             'content for typedoc.json',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, 'CHANGELOG.md'),
+            wellFormattedChangelog,
           );
         }
         const outputLogger = new FakeOutputLogger();
@@ -158,6 +179,8 @@ repo-1
   - Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
   - Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
   - Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
+  - Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -170,8 +193,10 @@ repo-1
 - Is \`tsconfig.build.json\` present, and does it conform? ✅
 - Is \`tsup.config.ts\` present, and does it conform? ✅
 - Is \`typedoc.json\` present, and does it conform? ✅
+- Is \`CHANGELOG.md\` present? ✅
+  - Is \`CHANGELOG.md\` well-formatted? ✅
 
-Results:       29 passed, 0 failed, 29 total
+Results:       33 passed, 0 failed, 33 total
 Elapsed time:  0 ms
 
 
@@ -195,6 +220,8 @@ repo-2
   - Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
   - Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
   - Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
+  - Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -207,8 +234,10 @@ repo-2
 - Is \`tsconfig.build.json\` present, and does it conform? ✅
 - Is \`tsup.config.ts\` present, and does it conform? ✅
 - Is \`typedoc.json\` present, and does it conform? ✅
+- Is \`CHANGELOG.md\` present? ✅
+  - Is \`CHANGELOG.md\` well-formatted? ✅
 
-Results:       29 passed, 0 failed, 29 total
+Results:       33 passed, 0 failed, 33 total
 Elapsed time:  0 ms
 
 `,
@@ -277,8 +306,10 @@ repo-1
   - \`tsup.config.ts\` does not exist in this project.
 - Is \`typedoc.json\` present, and does it conform? ❌
   - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ❌
+  - \`CHANGELOG.md\` does not exist in this project.
 
-Results:       0 passed, 11 failed, 11 total
+Results:       0 passed, 12 failed, 12 total
 Elapsed time:  0 ms
 
 
@@ -309,8 +340,10 @@ repo-2
   - \`tsup.config.ts\` does not exist in this project.
 - Is \`typedoc.json\` present, and does it conform? ❌
   - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ❌
+  - \`CHANGELOG.md\` does not exist in this project.
 
-Results:       0 passed, 11 failed, 11 total
+Results:       0 passed, 12 failed, 12 total
 Elapsed time:  0 ms
 
 `,
@@ -385,8 +418,10 @@ repo-2
   - \`tsup.config.ts\` does not exist in this project.
 - Is \`typedoc.json\` present, and does it conform? ❌
   - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ❌
+  - \`CHANGELOG.md\` does not exist in this project.
 
-Results:       1 passed, 10 failed, 11 total
+Results:       1 passed, 11 failed, 12 total
 Elapsed time:  0 ms
 
 `.trimStart(),
@@ -449,6 +484,7 @@ Elapsed time:  0 ms
                 tsup: '1.0.0',
                 typescript: '1.0.0',
                 typedoc: '1.0.0',
+                '@metamask/auto-changelog': '1.0.0',
               },
               scripts: {
                 test: 'test script',
@@ -456,6 +492,11 @@ Elapsed time:  0 ms
                 build: 'test build',
                 'build:types': 'test build types',
                 'build:docs': 'test build docs',
+                'lint:changelog': 'test changelog',
+                lint: 'test build types && yarn lint:changelog',
+              },
+              repository: {
+                url: 'https://github.com/MetaMask/module-lint.git',
               },
             }),
           );
@@ -486,6 +527,10 @@ Elapsed time:  0 ms
           await writeFile(
             path.join(repository.directoryPath, 'typedoc.json'),
             'content for typedoc.json',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, 'CHANGELOG.md'),
+            wellFormattedChangelog,
           );
         }
         const outputLogger = new FakeOutputLogger();
@@ -523,6 +568,8 @@ repo-1
   - Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
   - Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
   - Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
+  - Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -535,8 +582,10 @@ repo-1
 - Is \`tsconfig.build.json\` present, and does it conform? ✅
 - Is \`tsup.config.ts\` present, and does it conform? ✅
 - Is \`typedoc.json\` present, and does it conform? ✅
+- Is \`CHANGELOG.md\` present? ✅
+  - Is \`CHANGELOG.md\` well-formatted? ✅
 
-Results:       29 passed, 0 failed, 29 total
+Results:       33 passed, 0 failed, 33 total
 Elapsed time:  0 ms
 
 
@@ -560,6 +609,8 @@ repo-2
   - Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
   - Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
   - Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
+  - Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
+  - Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
 - Is \`README.md\` present? ✅
   - Does the README conform by recommending the correct Yarn version to install? ✅
   - Does the README conform by recommending node install from nodejs.org? ✅
@@ -572,8 +623,10 @@ repo-2
 - Is \`tsconfig.build.json\` present, and does it conform? ✅
 - Is \`tsup.config.ts\` present, and does it conform? ✅
 - Is \`typedoc.json\` present, and does it conform? ✅
+- Is \`CHANGELOG.md\` present? ✅
+  - Is \`CHANGELOG.md\` well-formatted? ✅
 
-Results:       29 passed, 0 failed, 29 total
+Results:       33 passed, 0 failed, 33 total
 Elapsed time:  0 ms
 
 `,
@@ -642,8 +695,10 @@ repo-1
   - \`tsup.config.ts\` does not exist in this project.
 - Is \`typedoc.json\` present, and does it conform? ❌
   - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ❌
+  - \`CHANGELOG.md\` does not exist in this project.
 
-Results:       0 passed, 11 failed, 11 total
+Results:       0 passed, 12 failed, 12 total
 Elapsed time:  0 ms
 
 
@@ -674,8 +729,10 @@ repo-2
   - \`tsup.config.ts\` does not exist in this project.
 - Is \`typedoc.json\` present, and does it conform? ❌
   - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ❌
+  - \`CHANGELOG.md\` does not exist in this project.
 
-Results:       0 passed, 11 failed, 11 total
+Results:       0 passed, 12 failed, 12 total
 Elapsed time:  0 ms
 
 `,
@@ -749,8 +806,10 @@ repo-2
   - \`tsup.config.ts\` does not exist in this project.
 - Is \`typedoc.json\` present, and does it conform? ❌
   - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ❌
+  - \`CHANGELOG.md\` does not exist in this project.
 
-Results:       1 passed, 10 failed, 11 total
+Results:       1 passed, 11 failed, 12 total
 Elapsed time:  0 ms
 
 `,

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -143,6 +143,18 @@ describe('main', () => {
             path.join(repository.directoryPath, 'CHANGELOG.md'),
             wellFormattedChangelog,
           );
+          await writeFile(
+            path.join(repository.directoryPath, '.editorconfig'),
+            'content for .editorconfig',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, '.gitattributes'),
+            'content for .gitattributes',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, '.gitignore'),
+            'content for .gitignore',
+          );
         }
         const outputLogger = new FakeOutputLogger();
 
@@ -195,8 +207,11 @@ repo-1
 - Is \`typedoc.json\` present, and does it conform? ✅
 - Is \`CHANGELOG.md\` present? ✅
   - Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
-Results:       33 passed, 0 failed, 33 total
+Results:       36 passed, 0 failed, 36 total
 Elapsed time:  0 ms
 
 
@@ -236,8 +251,11 @@ repo-2
 - Is \`typedoc.json\` present, and does it conform? ✅
 - Is \`CHANGELOG.md\` present? ✅
   - Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
-Results:       33 passed, 0 failed, 33 total
+Results:       36 passed, 0 failed, 36 total
 Elapsed time:  0 ms
 
 `,
@@ -308,8 +326,14 @@ repo-1
   - \`typedoc.json\` does not exist in this project.
 - Is \`CHANGELOG.md\` present? ❌
   - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 12 failed, 12 total
+Results:       0 passed, 15 failed, 15 total
 Elapsed time:  0 ms
 
 
@@ -342,8 +366,14 @@ repo-2
   - \`typedoc.json\` does not exist in this project.
 - Is \`CHANGELOG.md\` present? ❌
   - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 12 failed, 12 total
+Results:       0 passed, 15 failed, 15 total
 Elapsed time:  0 ms
 
 `,
@@ -420,8 +450,14 @@ repo-2
   - \`typedoc.json\` does not exist in this project.
 - Is \`CHANGELOG.md\` present? ❌
   - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       1 passed, 11 failed, 12 total
+Results:       1 passed, 14 failed, 15 total
 Elapsed time:  0 ms
 
 `.trimStart(),
@@ -532,6 +568,18 @@ Elapsed time:  0 ms
             path.join(repository.directoryPath, 'CHANGELOG.md'),
             wellFormattedChangelog,
           );
+          await writeFile(
+            path.join(repository.directoryPath, '.editorconfig'),
+            'content for .editorconfig',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, '.gitattributes'),
+            'content for .gitattributes',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, '.gitignore'),
+            'content for .gitignore',
+          );
         }
         const outputLogger = new FakeOutputLogger();
 
@@ -584,8 +632,11 @@ repo-1
 - Is \`typedoc.json\` present, and does it conform? ✅
 - Is \`CHANGELOG.md\` present? ✅
   - Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
-Results:       33 passed, 0 failed, 33 total
+Results:       36 passed, 0 failed, 36 total
 Elapsed time:  0 ms
 
 
@@ -625,8 +676,11 @@ repo-2
 - Is \`typedoc.json\` present, and does it conform? ✅
 - Is \`CHANGELOG.md\` present? ✅
   - Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
-Results:       33 passed, 0 failed, 33 total
+Results:       36 passed, 0 failed, 36 total
 Elapsed time:  0 ms
 
 `,
@@ -697,8 +751,14 @@ repo-1
   - \`typedoc.json\` does not exist in this project.
 - Is \`CHANGELOG.md\` present? ❌
   - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 12 failed, 12 total
+Results:       0 passed, 15 failed, 15 total
 Elapsed time:  0 ms
 
 
@@ -731,8 +791,14 @@ repo-2
   - \`typedoc.json\` does not exist in this project.
 - Is \`CHANGELOG.md\` present? ❌
   - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 12 failed, 12 total
+Results:       0 passed, 15 failed, 15 total
 Elapsed time:  0 ms
 
 `,
@@ -808,8 +874,14 @@ repo-2
   - \`typedoc.json\` does not exist in this project.
 - Is \`CHANGELOG.md\` present? ❌
   - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       1 passed, 11 failed, 12 total
+Results:       1 passed, 14 failed, 15 total
 Elapsed time:  0 ms
 
 `,

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -122,6 +122,18 @@ describe('main', () => {
             path.join(repository.directoryPath, 'typedoc.json'),
             'content for typedoc.json',
           );
+          await writeFile(
+            path.join(repository.directoryPath, '.editorconfig'),
+            'content for .editorconfig',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, '.gitattributes'),
+            'content for .gitattributes',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, '.gitignore'),
+            'content for .gitignore',
+          );
         }
         const outputLogger = new FakeOutputLogger();
 
@@ -170,8 +182,11 @@ repo-1
 - Is \`tsconfig.build.json\` present, and does it conform? ✅
 - Is \`tsup.config.ts\` present, and does it conform? ✅
 - Is \`typedoc.json\` present, and does it conform? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
-Results:       29 passed, 0 failed, 29 total
+Results:       32 passed, 0 failed, 32 total
 Elapsed time:  0 ms
 
 
@@ -207,8 +222,11 @@ repo-2
 - Is \`tsconfig.build.json\` present, and does it conform? ✅
 - Is \`tsup.config.ts\` present, and does it conform? ✅
 - Is \`typedoc.json\` present, and does it conform? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
-Results:       29 passed, 0 failed, 29 total
+Results:       32 passed, 0 failed, 32 total
 Elapsed time:  0 ms
 
 `,
@@ -277,8 +295,14 @@ repo-1
   - \`tsup.config.ts\` does not exist in this project.
 - Is \`typedoc.json\` present, and does it conform? ❌
   - \`typedoc.json\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 11 failed, 11 total
+Results:       0 passed, 14 failed, 14 total
 Elapsed time:  0 ms
 
 
@@ -309,8 +333,14 @@ repo-2
   - \`tsup.config.ts\` does not exist in this project.
 - Is \`typedoc.json\` present, and does it conform? ❌
   - \`typedoc.json\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 11 failed, 11 total
+Results:       0 passed, 14 failed, 14 total
 Elapsed time:  0 ms
 
 `,
@@ -385,8 +415,14 @@ repo-2
   - \`tsup.config.ts\` does not exist in this project.
 - Is \`typedoc.json\` present, and does it conform? ❌
   - \`typedoc.json\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       1 passed, 10 failed, 11 total
+Results:       1 passed, 13 failed, 14 total
 Elapsed time:  0 ms
 
 `.trimStart(),
@@ -487,6 +523,18 @@ Elapsed time:  0 ms
             path.join(repository.directoryPath, 'typedoc.json'),
             'content for typedoc.json',
           );
+          await writeFile(
+            path.join(repository.directoryPath, '.editorconfig'),
+            'content for .editorconfig',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, '.gitattributes'),
+            'content for .gitattributes',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, '.gitignore'),
+            'content for .gitignore',
+          );
         }
         const outputLogger = new FakeOutputLogger();
 
@@ -535,8 +583,11 @@ repo-1
 - Is \`tsconfig.build.json\` present, and does it conform? ✅
 - Is \`tsup.config.ts\` present, and does it conform? ✅
 - Is \`typedoc.json\` present, and does it conform? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
-Results:       29 passed, 0 failed, 29 total
+Results:       32 passed, 0 failed, 32 total
 Elapsed time:  0 ms
 
 
@@ -572,8 +623,11 @@ repo-2
 - Is \`tsconfig.build.json\` present, and does it conform? ✅
 - Is \`tsup.config.ts\` present, and does it conform? ✅
 - Is \`typedoc.json\` present, and does it conform? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
-Results:       29 passed, 0 failed, 29 total
+Results:       32 passed, 0 failed, 32 total
 Elapsed time:  0 ms
 
 `,
@@ -642,8 +696,14 @@ repo-1
   - \`tsup.config.ts\` does not exist in this project.
 - Is \`typedoc.json\` present, and does it conform? ❌
   - \`typedoc.json\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 11 failed, 11 total
+Results:       0 passed, 14 failed, 14 total
 Elapsed time:  0 ms
 
 
@@ -674,8 +734,14 @@ repo-2
   - \`tsup.config.ts\` does not exist in this project.
 - Is \`typedoc.json\` present, and does it conform? ❌
   - \`typedoc.json\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 11 failed, 11 total
+Results:       0 passed, 14 failed, 14 total
 Elapsed time:  0 ms
 
 `,
@@ -749,8 +815,14 @@ repo-2
   - \`tsup.config.ts\` does not exist in this project.
 - Is \`typedoc.json\` present, and does it conform? ❌
   - \`typedoc.json\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       1 passed, 10 failed, 11 total
+Results:       1 passed, 13 failed, 14 total
 Elapsed time:  0 ms
 
 `,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -17,6 +17,9 @@ import packageTypescriptDevDependenciesConform from './package-typescript-dev-de
 import packageTypescriptScriptsConform from './package-typescript-scripts-conform';
 import readmeListsCorrectYarnVersion from './readme-lists-correct-yarn-version';
 import readmeListsNodejsWebsite from './readme-recommends-node-install';
+import requireEditorconfig from './require-editorconfig';
+import requireGitattributes from './require-gitattributes';
+import requireGitignore from './require-gitignore';
 import requireJestConfig from './require-jest-config';
 import requireNvmrc from './require-nvmrc';
 import requireReadme from './require-readme';
@@ -56,4 +59,7 @@ export const rules = [
   packageTypedocDevDependenciesConform,
   packageTypedocScriptsConform,
   requireTypedoc,
+  requireEditorconfig,
+  requireGitattributes,
+  requireGitignore,
 ] as const;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,5 +1,7 @@
 import allYarnModernFilesConform from './all-yarn-modern-files-conform';
 import classicYarnConfigFileAbsent from './classic-yarn-config-file-absent';
+import packageChangelogDevDependenciesConform from './package-changelog-dev-dependencies-conform';
+import packageChangelogScriptsConform from './package-changelog-scripts-conform';
 import packageEnginesNodeFieldConforms from './package-engines-node-field-conforms';
 import packageExportsFieldConforms from './package-exports-field-conforms';
 import packageFilesFieldConforms from './package-files-field-conforms';
@@ -17,6 +19,7 @@ import packageTypescriptDevDependenciesConform from './package-typescript-dev-de
 import packageTypescriptScriptsConform from './package-typescript-scripts-conform';
 import readmeListsCorrectYarnVersion from './readme-lists-correct-yarn-version';
 import readmeListsNodejsWebsite from './readme-recommends-node-install';
+import requireChangelog from './require-changelog';
 import requireJestConfig from './require-jest-config';
 import requireNvmrc from './require-nvmrc';
 import requireReadme from './require-readme';
@@ -25,6 +28,7 @@ import requireTsconfig from './require-tsconfig';
 import requireTsconfigBuild from './require-tsconfig-build';
 import requireTsupConfig from './require-tsup-config';
 import requireTypedoc from './require-typedoc';
+import requireValidChangelog from './require-valid-changelog';
 import requireValidPackageManifest from './require-valid-package-manifest';
 
 export const rules = [
@@ -56,4 +60,8 @@ export const rules = [
   packageTypedocDevDependenciesConform,
   packageTypedocScriptsConform,
   requireTypedoc,
+  requireChangelog,
+  requireValidChangelog,
+  packageChangelogDevDependenciesConform,
+  packageChangelogScriptsConform,
 ] as const;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -20,6 +20,9 @@ import packageTypescriptScriptsConform from './package-typescript-scripts-confor
 import readmeListsCorrectYarnVersion from './readme-lists-correct-yarn-version';
 import readmeListsNodejsWebsite from './readme-recommends-node-install';
 import requireChangelog from './require-changelog';
+import requireEditorconfig from './require-editorconfig';
+import requireGitattributes from './require-gitattributes';
+import requireGitignore from './require-gitignore';
 import requireJestConfig from './require-jest-config';
 import requireNvmrc from './require-nvmrc';
 import requireReadme from './require-readme';
@@ -64,4 +67,7 @@ export const rules = [
   requireValidChangelog,
   packageChangelogDevDependenciesConform,
   packageChangelogScriptsConform,
+  requireEditorconfig,
+  requireGitattributes,
+  requireGitignore,
 ] as const;

--- a/src/rules/package-changelog-dev-dependencies-conform.test.ts
+++ b/src/rules/package-changelog-dev-dependencies-conform.test.ts
@@ -1,0 +1,178 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import packageChangelogDevDependenciesConform from './package-changelog-dev-dependencies-conform';
+import {
+  buildMetaMaskRepository,
+  buildPackageManifestMock,
+  withinSandbox,
+} from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: package-changelog-dev-dependencies-conform', () => {
+  it('passes if the changelog related devDependencies of template exist in project with the version matching', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            '@metamask/auto-changelog': '1.0.0',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            '@metamask/auto-changelog': '1.0.0',
+          },
+        }),
+      );
+      const result = await packageChangelogDevDependenciesConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({ passed: true });
+    });
+  });
+
+  it('fails if the changelog related devDependencies of template exist in project, but its version does not match', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            '@metamask/auto-changelog': '1.0.0',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            '@metamask/auto-changelog': '0.0.1',
+          },
+        }),
+      );
+      const result = await packageChangelogDevDependenciesConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message:
+              "`devDependencies.[@metamask/auto-changelog]` is '0.0.1', when it should be '1.0.0'.",
+          },
+        ],
+      });
+    });
+  });
+
+  it('fails if the changelog related devDependencies does not exist in project', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            '@metamask/auto-changelog': '1.0.0',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            test: '1.0.0',
+          },
+        }),
+      );
+      const result = await packageChangelogDevDependenciesConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message:
+              "`package.json` should list `'devDependencies.[@metamask/auto-changelog]': '1.0.0'`, but does not.",
+          },
+        ],
+      });
+    });
+  });
+
+  it('throws error if the changelog related devDependencies does not exist in the template', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            test: '1.0.0',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          devDependencies: {
+            '@metamask/auto-changelog': '1.0.0',
+          },
+        }),
+      );
+      await expect(
+        packageChangelogDevDependenciesConform.execute({
+          template,
+          project,
+          pass,
+          fail,
+        }),
+      ).rejects.toThrow(
+        'Could not find `devDependencies.[@metamask/auto-changelog]` in reference `package.json`. This is not the fault of the target `package.json`, but is rather a bug in a rule.',
+      );
+    });
+  });
+});

--- a/src/rules/package-changelog-dev-dependencies-conform.ts
+++ b/src/rules/package-changelog-dev-dependencies-conform.ts
@@ -1,0 +1,16 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { packageManifestPropertiesConform } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.PackageChangelogDependenciesConform,
+  description:
+    'Do the changelog-related `devDependencies` in `package.json` conform?',
+  dependencies: [RuleName.RequireValidPackageManifest],
+  execute: async (ruleExecutionArguments) => {
+    return packageManifestPropertiesConform(
+      ['devDependencies.[@metamask/auto-changelog]'],
+      ruleExecutionArguments,
+    );
+  },
+});

--- a/src/rules/package-changelog-scripts-conform.test.ts
+++ b/src/rules/package-changelog-scripts-conform.test.ts
@@ -1,0 +1,269 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import packageChangelogScriptsConform from './package-changelog-scripts-conform';
+import {
+  buildMetaMaskRepository,
+  buildPackageManifestMock,
+  withinSandbox,
+} from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: package-changelog-scripts-conform', () => {
+  it('passes if the project and template have the `lint:changelog` in scripts and matches and lint scripts contains `yarn lint:changelog`', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: {
+            'lint:changelog': 'test changelog',
+            lint: 'test build types && yarn lint:changelog',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: {
+            'lint:changelog': 'test changelog',
+            lint: 'test build types && yarn lint:changelog',
+          },
+        }),
+      );
+      const result = await packageChangelogScriptsConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({ passed: true });
+    });
+  });
+
+  it('fails if the project and template have the `lint:changelog` in scripts, but does not match', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: {
+            'lint:changelog': 'test changelog',
+            lint: 'test build types && yarn lint:changelog',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: {
+            'lint:changelog': 'test',
+            lint: 'test build types && yarn lint:changelog',
+          },
+        }),
+      );
+      const result = await packageChangelogScriptsConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message:
+              "`scripts.[lint:changelog]` is 'test', when it should be 'test changelog'.",
+          },
+        ],
+      });
+    });
+  });
+
+  it('fails if the project does not have the `lint:changelog` in scripts', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: {
+            'lint:changelog': 'test changelog',
+            lint: 'test build types && yarn lint:changelog',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: {
+            lint: 'test build types && yarn lint:changelog',
+          },
+        }),
+      );
+      const result = await packageChangelogScriptsConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message:
+              "`package.json` should list `'scripts.[lint:changelog]': 'test changelog'`, but does not.",
+          },
+        ],
+      });
+    });
+  });
+
+  it('throws error if the script does not exist in the template scripts', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: {
+            lint: 'test build types && yarn lint:changelog',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: {
+            'lint:changelog': 'test changelog',
+            lint: 'test build types && yarn lint:changelog',
+          },
+        }),
+      );
+      await expect(
+        packageChangelogScriptsConform.execute({
+          template,
+          project,
+          pass,
+          fail,
+        }),
+      ).rejects.toThrow(
+        'Could not find `scripts.[lint:changelog]` in reference `package.json`. This is not the fault of the target `package.json`, but is rather a bug in a rule.',
+      );
+    });
+  });
+
+  it('passes if the project and template have the `lint:changelog` in scripts and matches and there is no lint scripts', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: {
+            'lint:changelog': 'test changelog',
+            lint: 'test build types && yarn lint:changelog',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: {
+            'lint:changelog': 'test changelog',
+          },
+        }),
+      );
+      const result = await packageChangelogScriptsConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({ passed: true });
+    });
+  });
+
+  it('fails if the project has lint scripts, but does not match the `yarn lint:changelog`', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: {
+            'lint:changelog': 'test changelog',
+            lint: 'test build types && yarn lint:changelog',
+          },
+        }),
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          scripts: {
+            'lint:changelog': 'test changelog',
+            lint: 'test build types && yarn lint:changelogs',
+          },
+        }),
+      );
+      const result = await packageChangelogScriptsConform.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message:
+              '`scripts.[lint]` exists, but it does not include `yarn lint:changelog`.',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/rules/package-changelog-scripts-conform.ts
+++ b/src/rules/package-changelog-scripts-conform.ts
@@ -1,0 +1,42 @@
+import { get, has } from 'lodash';
+
+import { buildRule } from './build-rule';
+import { PackageManifestSchema, RuleName } from './types';
+import {
+  combineRuleExecutionResults,
+  packageManifestPropertiesConform,
+} from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.PackageChangelogScriptsConform,
+  description: 'Do the changelog-related `scripts` in `package.json` conform?',
+  dependencies: [RuleName.RequireValidPackageManifest],
+  execute: async (ruleExecutionArguments) => {
+    // check: project contains the same `lint:changelog` package script as in the module template
+    const result = await packageManifestPropertiesConform(
+      ['scripts.[lint:changelog]'],
+      ruleExecutionArguments,
+    );
+
+    // check: If the `lint` script exists, then the `lint` script contains `yarn lint:changelog`
+    const { project, pass, fail } = ruleExecutionArguments;
+    const projectManifest = await project.fs.readJsonFileAs(
+      'package.json',
+      PackageManifestSchema,
+    );
+    if (has(projectManifest.scripts, 'lint')) {
+      const lintScripts = get(projectManifest.scripts, 'lint');
+      const lintResult = lintScripts.match(/\byarn lint:changelog\b/u)
+        ? pass()
+        : fail([
+            {
+              message:
+                '`scripts.[lint]` exists, but it does not include `yarn lint:changelog`.',
+            },
+          ]);
+      return combineRuleExecutionResults([result, lintResult]);
+    }
+
+    return result;
+  },
+});

--- a/src/rules/require-changelog.test.ts
+++ b/src/rules/require-changelog.test.ts
@@ -1,23 +1,23 @@
 import { writeFile } from '@metamask/utils/node';
 import path from 'path';
 
-import requireReadme from './require-readme';
+import requireChangelog from './require-changelog';
 import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
 import { fail, pass } from '../rule-helpers';
 
-describe('Rule: require-readme', () => {
-  it('passes if the project has a README.md', async () => {
+describe('Rule: require-changelog', () => {
+  it('passes if the project has a CHANGELOG.md', async () => {
     await withinSandbox(async (sandbox) => {
       const project = buildMetaMaskRepository({
         shortname: 'project',
         directoryPath: path.join(sandbox.directoryPath, 'project'),
       });
       await writeFile(
-        path.join(project.directoryPath, 'README.md'),
-        'content for README',
+        path.join(project.directoryPath, 'CHANGELOG.md'),
+        'content for CHANGELOG',
       );
 
-      const result = await requireReadme.execute({
+      const result = await requireChangelog.execute({
         template: buildMetaMaskRepository(),
         project,
         pass,
@@ -30,14 +30,14 @@ describe('Rule: require-readme', () => {
     });
   });
 
-  it('fails if the project does not have a README.md', async () => {
+  it('fails if the project does not have a CHANGELOG.md', async () => {
     await withinSandbox(async (sandbox) => {
       const project = buildMetaMaskRepository({
         shortname: 'project',
         directoryPath: path.join(sandbox.directoryPath, 'project'),
       });
 
-      const result = await requireReadme.execute({
+      const result = await requireChangelog.execute({
         template: buildMetaMaskRepository(),
         project,
         pass,
@@ -48,7 +48,7 @@ describe('Rule: require-readme', () => {
         passed: false,
         failures: [
           {
-            message: '`README.md` does not exist in this project.',
+            message: '`CHANGELOG.md` does not exist in this project.',
           },
         ],
       });

--- a/src/rules/require-changelog.ts
+++ b/src/rules/require-changelog.ts
@@ -1,0 +1,12 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { fileExists } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.RequireChangelog,
+  description: 'Is `CHANGELOG.md` present?',
+  dependencies: [],
+  execute: async (ruleExecutionArguments) => {
+    return fileExists('CHANGELOG.md', ruleExecutionArguments);
+  },
+});

--- a/src/rules/require-editorconfig.test.ts
+++ b/src/rules/require-editorconfig.test.ts
@@ -1,0 +1,73 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import requireEditorconfig from './require-editorconfig';
+import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: require-editorconfig', () => {
+  it('passes if the project has a .editorconfig', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.editorconfig'),
+        'contents of editorconfig',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, '.editorconfig'),
+        'contents of editorconfig',
+      );
+
+      const result = await requireEditorconfig.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: true,
+      });
+    });
+  });
+
+  it('fails with failure message when .editorconfig does not exist', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.editorconfig'),
+        'contents of editorconfig',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+
+      const result = await requireEditorconfig.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message: '`.editorconfig` does not exist in this project.',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/rules/require-editorconfig.ts
+++ b/src/rules/require-editorconfig.ts
@@ -1,0 +1,12 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { fileConforms } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.RequireEditorConfig,
+  description: 'Is `.editorconfig` present, and does it conform?',
+  dependencies: [],
+  execute: async (ruleExecutionArguments) => {
+    return await fileConforms('.editorconfig', ruleExecutionArguments);
+  },
+});

--- a/src/rules/require-gitattributes.test.ts
+++ b/src/rules/require-gitattributes.test.ts
@@ -1,0 +1,73 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import requireGitattributes from './require-gitattributes';
+import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: require-gitattributes', () => {
+  it('passes if the project has a .gitattributes', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.gitattributes'),
+        'contents of gitattributes',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, '.gitattributes'),
+        'contents of gitattributes',
+      );
+
+      const result = await requireGitattributes.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: true,
+      });
+    });
+  });
+
+  it('fails with failure message when .gitattributes does not exist', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.gitattributes'),
+        'contents of gitattributes',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+
+      const result = await requireGitattributes.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message: '`.gitattributes` does not exist in this project.',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/rules/require-gitattributes.ts
+++ b/src/rules/require-gitattributes.ts
@@ -1,0 +1,12 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { fileConforms } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.RequireGitAttributes,
+  description: 'Is `.gitattributes` present, and does it conform?',
+  dependencies: [],
+  execute: async (ruleExecutionArguments) => {
+    return await fileConforms('.gitattributes', ruleExecutionArguments);
+  },
+});

--- a/src/rules/require-gitignore.test.ts
+++ b/src/rules/require-gitignore.test.ts
@@ -1,0 +1,73 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import requireGitignore from './require-gitignore';
+import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: require-gitignore', () => {
+  it('passes if the project has a .gitignore', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.gitignore'),
+        'contents of gitignore',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, '.gitignore'),
+        'contents of gitignore',
+      );
+
+      const result = await requireGitignore.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: true,
+      });
+    });
+  });
+
+  it('fails with failure message when .gitignore does not exist', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.gitignore'),
+        'contents of gitignore',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+
+      const result = await requireGitignore.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message: '`.gitignore` does not exist in this project.',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/rules/require-gitignore.ts
+++ b/src/rules/require-gitignore.ts
@@ -1,0 +1,12 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { fileConforms } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.RequireGitIgnore,
+  description: 'Is `.gitignore` present, and does it conform?',
+  dependencies: [],
+  execute: async (ruleExecutionArguments) => {
+    return await fileConforms('.gitignore', ruleExecutionArguments);
+  },
+});

--- a/src/rules/require-source-directory.test.ts
+++ b/src/rules/require-source-directory.test.ts
@@ -32,7 +32,7 @@ describe('Rule: require-source-directory', () => {
     });
   });
 
-  it('passes if the project does not have a src/ directory', async () => {
+  it('fails if the project does not have a src/ directory', async () => {
     await withinSandbox(async (sandbox) => {
       const project = buildMetaMaskRepository({
         shortname: 'project',

--- a/src/rules/require-valid-changelog.test.ts
+++ b/src/rules/require-valid-changelog.test.ts
@@ -1,0 +1,168 @@
+import { getErrorMessage, writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import validateChangelog from './require-valid-changelog';
+import {
+  buildMetaMaskRepository,
+  buildPackageManifestMock,
+  withinSandbox,
+} from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+const wellFormattedChangelog = `# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/module-lint/
+`;
+
+const invalidChangelog = `# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/module-lint/`;
+
+describe('Rule: require-valid-changelog', () => {
+  it('passes if the changelog.md is well formatted', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          version: '0.0.0',
+          repository: { url: 'https://github.com/MetaMask/module-lint.git' },
+        }),
+      );
+      await writeFile(
+        path.join(project.directoryPath, 'CHANGELOG.md'),
+        wellFormattedChangelog,
+      );
+
+      const result = await validateChangelog.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: true,
+      });
+    });
+  });
+
+  it('fails if the changelog.md is not well formatted', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        buildPackageManifestMock({
+          version: '0.0.0',
+          repository: { url: 'https://github.com/MetaMask/module-lint.git' },
+        }),
+      );
+      await writeFile(
+        path.join(project.directoryPath, 'CHANGELOG.md'),
+        invalidChangelog,
+      );
+
+      const result = await validateChangelog.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message: 'Changelog is not well-formatted.',
+          },
+        ],
+      });
+    });
+  });
+
+  it('fails if the package manifest is not well formed', async () => {
+    await withinSandbox(async (sandbox) => {
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        JSON.stringify({ foo: 'bar' }),
+      );
+      await writeFile(
+        path.join(project.directoryPath, 'CHANGELOG.md'),
+        invalidChangelog,
+      );
+
+      await expect(
+        validateChangelog.execute({
+          template: buildMetaMaskRepository(),
+          project,
+          pass,
+          fail,
+        }),
+      ).rejects.toThrow(
+        'The package does not have a well-formed manifest. This is not the fault of the changelog, but this rule requires a valid package manifest.',
+      );
+    });
+  });
+
+  it('re-throws a unknown error where there is no error code or it is not an instance of ChangelogFormattingError', async () => {
+    await withinSandbox(async (sandbox) => {
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, 'package.json'),
+        JSON.stringify({ foo: 'bar' }),
+      );
+      await writeFile(
+        path.join(project.directoryPath, 'CHANGELOG.md'),
+        wellFormattedChangelog,
+      );
+      const error = new Error('unknown error');
+      jest.spyOn(project.fs, 'readJsonFileAs').mockRejectedValueOnce(error);
+
+      await expect(
+        validateChangelog.execute({
+          template: buildMetaMaskRepository(),
+          project,
+          pass,
+          fail,
+        }),
+      ).rejects.toThrow(
+        `Encountered an error validating the changelog: ${getErrorMessage(
+          error,
+        )}.`,
+      );
+    });
+  });
+});

--- a/src/rules/require-valid-changelog.ts
+++ b/src/rules/require-valid-changelog.ts
@@ -1,0 +1,49 @@
+import {
+  ChangelogFormattingError,
+  validateChangelog,
+} from '@metamask/auto-changelog';
+import { getErrorMessage, isErrorWithCode } from '@metamask/utils/node';
+
+import { buildRule } from './build-rule';
+import { PackageManifestSchema, RuleName } from './types';
+
+export default buildRule({
+  name: RuleName.RequireValidChangelog,
+  description: 'Is `CHANGELOG.md` well-formatted?',
+  dependencies: [RuleName.RequireChangelog],
+  execute: async (ruleExecutionArguments) => {
+    const { project, pass, fail } = ruleExecutionArguments;
+    const oldChangelog = await project.fs.readFile('CHANGELOG.md');
+    try {
+      const projectManifest = await project.fs.readJsonFileAs(
+        'package.json',
+        PackageManifestSchema,
+      );
+
+      validateChangelog({
+        changelogContent: oldChangelog,
+        currentVersion: projectManifest.version,
+        repoUrl: projectManifest.repository.url.replace('.git', ''),
+        isReleaseCandidate: false,
+      });
+      return pass();
+    } catch (error) {
+      if (isErrorWithCode(error) && error.code === 'ERR_INVALID_JSON_FILE') {
+        throw new Error(
+          'The package does not have a well-formed manifest. This is not the fault of the changelog, but this rule requires a valid package manifest.',
+        );
+      } else if (error instanceof ChangelogFormattingError) {
+        return fail([
+          {
+            message: 'Changelog is not well-formatted.',
+          },
+        ]);
+      }
+      throw new Error(
+        `Encountered an error validating the changelog: ${getErrorMessage(
+          error,
+        )}.`,
+      );
+    }
+  },
+});

--- a/src/rules/require-valid-package-manifest.test.ts
+++ b/src/rules/require-valid-package-manifest.test.ts
@@ -82,7 +82,7 @@ describe('Rule: require-package-manifest', () => {
         failures: [
           {
             message:
-              'Invalid `package.json`: Missing `packageManager`; Missing `engines`; Missing `exports`; Missing `main`; Missing `module`; Missing `types`; Missing `files`; Missing `scripts`; Missing `devDependencies`.',
+              'Invalid `package.json`: Missing `version`; Missing `packageManager`; Missing `engines`; Missing `exports`; Missing `main`; Missing `module`; Missing `types`; Missing `files`; Missing `scripts`; Missing `devDependencies`; Missing `repository`.',
           },
         ],
       });

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -32,6 +32,9 @@ export enum RuleName {
   PackageTypedocDependenciesConform = 'package-typedoc-dependencies-conform',
   RequireTypedoc = 'require-typedoc',
   PackageTypedocScriptsConform = 'package-typedoc-scripts-conform',
+  RequireEditorConfig = 'require-editorconfig',
+  RequireGitAttributes = 'require-gitattributes',
+  RequireGitIgnore = 'require-gitignore',
 }
 
 export const PackageManifestSchema = type({

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -37,6 +37,9 @@ export enum RuleName {
   PackageChangelogDependenciesConform = 'package-changelog-dependencies-conform',
   PackageChangelogScriptsConform = 'package-changelog-scripts-conform',
   PackageChangelogModuleLintDependenciesConform = 'package-changelog-module-lint-dependencies-conform',
+  RequireEditorConfig = 'require-editorconfig',
+  RequireGitAttributes = 'require-gitattributes',
+  RequireGitIgnore = 'require-gitignore',
 }
 
 export const PackageManifestSchema = type({

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -32,9 +32,15 @@ export enum RuleName {
   PackageTypedocDependenciesConform = 'package-typedoc-dependencies-conform',
   RequireTypedoc = 'require-typedoc',
   PackageTypedocScriptsConform = 'package-typedoc-scripts-conform',
+  RequireChangelog = 'require-changelog',
+  RequireValidChangelog = 'require-valid-changelog',
+  PackageChangelogDependenciesConform = 'package-changelog-dependencies-conform',
+  PackageChangelogScriptsConform = 'package-changelog-scripts-conform',
+  PackageChangelogModuleLintDependenciesConform = 'package-changelog-module-lint-dependencies-conform',
 }
 
 export const PackageManifestSchema = type({
+  version: string(),
   packageManager: string(),
   engines: type({
     node: string(),
@@ -49,4 +55,7 @@ export const PackageManifestSchema = type({
   files: array(string()),
   scripts: record(string(), string()),
   devDependencies: record(string(), string()),
+  repository: type({
+    url: string(),
+  }),
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -153,6 +153,7 @@ export function buildPackageManifestMock(
   overrides?: Record<string, unknown>,
 ): string {
   const validPackageManifestMock = {
+    version: '0.0.0',
     packageManager: 'yarn',
     engines: { node: '1.0.0' },
     main: 'test-main',
@@ -162,6 +163,9 @@ export function buildPackageManifestMock(
     exports: {
       '.': {},
       './package.json': 'test',
+    },
+    repository: {
+      url: 'http://',
     },
     devDependencies: {},
     scripts: {},


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
We want to make sure that for a given project:

.editorconfig is present and matches the same content as in the module template
.gitattributes is present and matches the same content as in the module template
.gitignore is present, and the project's version of the file starts with the template's version

* Fixes #61 
