### PR TITLE
checks for .editorconfig .gitattributes .gitignore

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -143,6 +143,18 @@ describe('main', () => {
             path.join(repository.directoryPath, 'CHANGELOG.md'),
             wellFormattedChangelog,
           );
+          await writeFile(
+            path.join(repository.directoryPath, '.editorconfig'),
+            'content for .editorconfig',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, '.gitattributes'),
+            'content for .gitattributes',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, '.gitignore'),
+            'content for .gitignore',
+          );
         }
         const outputLogger = new FakeOutputLogger();
 
@@ -195,8 +207,11 @@ repo-1
 - Is \`typedoc.json\` present, and does it conform? ✅
 - Is \`CHANGELOG.md\` present? ✅
   - Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
-Results:       33 passed, 0 failed, 33 total
+Results:       36 passed, 0 failed, 36 total
 Elapsed time:  0 ms
 
 
@@ -236,8 +251,11 @@ repo-2
 - Is \`typedoc.json\` present, and does it conform? ✅
 - Is \`CHANGELOG.md\` present? ✅
   - Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
-Results:       33 passed, 0 failed, 33 total
+Results:       36 passed, 0 failed, 36 total
 Elapsed time:  0 ms
 
 `,
@@ -308,8 +326,14 @@ repo-1
   - \`typedoc.json\` does not exist in this project.
 - Is \`CHANGELOG.md\` present? ❌
   - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 12 failed, 12 total
+Results:       0 passed, 15 failed, 15 total
 Elapsed time:  0 ms
 
 
@@ -342,8 +366,14 @@ repo-2
   - \`typedoc.json\` does not exist in this project.
 - Is \`CHANGELOG.md\` present? ❌
   - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 12 failed, 12 total
+Results:       0 passed, 15 failed, 15 total
 Elapsed time:  0 ms
 
 `,
@@ -420,8 +450,14 @@ repo-2
   - \`typedoc.json\` does not exist in this project.
 - Is \`CHANGELOG.md\` present? ❌
   - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       1 passed, 11 failed, 12 total
+Results:       1 passed, 14 failed, 15 total
 Elapsed time:  0 ms
 
 `.trimStart(),
@@ -532,6 +568,18 @@ Elapsed time:  0 ms
             path.join(repository.directoryPath, 'CHANGELOG.md'),
             wellFormattedChangelog,
           );
+          await writeFile(
+            path.join(repository.directoryPath, '.editorconfig'),
+            'content for .editorconfig',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, '.gitattributes'),
+            'content for .gitattributes',
+          );
+          await writeFile(
+            path.join(repository.directoryPath, '.gitignore'),
+            'content for .gitignore',
+          );
         }
         const outputLogger = new FakeOutputLogger();
 
@@ -584,8 +632,11 @@ repo-1
 - Is \`typedoc.json\` present, and does it conform? ✅
 - Is \`CHANGELOG.md\` present? ✅
   - Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
-Results:       33 passed, 0 failed, 33 total
+Results:       36 passed, 0 failed, 36 total
 Elapsed time:  0 ms
 
 
@@ -625,8 +676,11 @@ repo-2
 - Is \`typedoc.json\` present, and does it conform? ✅
 - Is \`CHANGELOG.md\` present? ✅
   - Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
-Results:       33 passed, 0 failed, 33 total
+Results:       36 passed, 0 failed, 36 total
 Elapsed time:  0 ms
 
 `,
@@ -697,8 +751,14 @@ repo-1
   - \`typedoc.json\` does not exist in this project.
 - Is \`CHANGELOG.md\` present? ❌
   - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 12 failed, 12 total
+Results:       0 passed, 15 failed, 15 total
 Elapsed time:  0 ms
 
 
@@ -731,8 +791,14 @@ repo-2
   - \`typedoc.json\` does not exist in this project.
 - Is \`CHANGELOG.md\` present? ❌
   - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 12 failed, 12 total
+Results:       0 passed, 15 failed, 15 total
 Elapsed time:  0 ms
 
 `,
@@ -808,8 +874,14 @@ repo-2
   - \`typedoc.json\` does not exist in this project.
 - Is \`CHANGELOG.md\` present? ❌
   - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
-Results:       1 passed, 11 failed, 12 total
+Results:       1 passed, 14 failed, 15 total
 Elapsed time:  0 ms
 
 `,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -20,6 +20,9 @@ import packageTypescriptScriptsConform from './package-typescript-scripts-confor
 import readmeListsCorrectYarnVersion from './readme-lists-correct-yarn-version';
 import readmeListsNodejsWebsite from './readme-recommends-node-install';
 import requireChangelog from './require-changelog';
+import requireEditorconfig from './require-editorconfig';
+import requireGitattributes from './require-gitattributes';
+import requireGitignore from './require-gitignore';
 import requireJestConfig from './require-jest-config';
 import requireNvmrc from './require-nvmrc';
 import requireReadme from './require-readme';
@@ -64,4 +67,7 @@ export const rules = [
   requireValidChangelog,
   packageChangelogDevDependenciesConform,
   packageChangelogScriptsConform,
+  requireEditorconfig,
+  requireGitattributes,
+  requireGitignore,
 ] as const;

--- a/src/rules/require-editorconfig.test.ts
+++ b/src/rules/require-editorconfig.test.ts
@@ -1,0 +1,73 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import requireEditorconfig from './require-editorconfig';
+import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: require-editorconfig', () => {
+  it('passes if the project has a .editorconfig', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.editorconfig'),
+        'contents of editorconfig',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, '.editorconfig'),
+        'contents of editorconfig',
+      );
+
+      const result = await requireEditorconfig.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: true,
+      });
+    });
+  });
+
+  it('fails with failure message when .editorconfig does not exist', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.editorconfig'),
+        'contents of editorconfig',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+
+      const result = await requireEditorconfig.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message: '`.editorconfig` does not exist in this project.',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/rules/require-editorconfig.ts
+++ b/src/rules/require-editorconfig.ts
@@ -1,0 +1,12 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { fileConforms } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.RequireEditorConfig,
+  description: 'Is `.editorconfig` present, and does it conform?',
+  dependencies: [],
+  execute: async (ruleExecutionArguments) => {
+    return await fileConforms('.editorconfig', ruleExecutionArguments);
+  },
+});

--- a/src/rules/require-gitattributes.test.ts
+++ b/src/rules/require-gitattributes.test.ts
@@ -1,0 +1,73 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import requireGitattributes from './require-gitattributes';
+import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: require-gitattributes', () => {
+  it('passes if the project has a .gitattributes', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.gitattributes'),
+        'contents of gitattributes',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, '.gitattributes'),
+        'contents of gitattributes',
+      );
+
+      const result = await requireGitattributes.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: true,
+      });
+    });
+  });
+
+  it('fails with failure message when .gitattributes does not exist', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.gitattributes'),
+        'contents of gitattributes',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+
+      const result = await requireGitattributes.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message: '`.gitattributes` does not exist in this project.',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/rules/require-gitattributes.ts
+++ b/src/rules/require-gitattributes.ts
@@ -1,0 +1,12 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { fileConforms } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.RequireGitAttributes,
+  description: 'Is `.gitattributes` present, and does it conform?',
+  dependencies: [],
+  execute: async (ruleExecutionArguments) => {
+    return await fileConforms('.gitattributes', ruleExecutionArguments);
+  },
+});

--- a/src/rules/require-gitignore.test.ts
+++ b/src/rules/require-gitignore.test.ts
@@ -1,0 +1,73 @@
+import { writeFile } from '@metamask/utils/node';
+import path from 'path';
+
+import requireGitignore from './require-gitignore';
+import { buildMetaMaskRepository, withinSandbox } from '../../tests/helpers';
+import { fail, pass } from '../rule-helpers';
+
+describe('Rule: require-gitignore', () => {
+  it('passes if the project has a .gitignore', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.gitignore'),
+        'contents of gitignore',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+      await writeFile(
+        path.join(project.directoryPath, '.gitignore'),
+        'contents of gitignore',
+      );
+
+      const result = await requireGitignore.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: true,
+      });
+    });
+  });
+
+  it('fails with failure message when .gitignore does not exist', async () => {
+    await withinSandbox(async (sandbox) => {
+      const template = buildMetaMaskRepository({
+        shortname: 'template',
+        directoryPath: path.join(sandbox.directoryPath, 'template'),
+      });
+      await writeFile(
+        path.join(template.directoryPath, '.gitignore'),
+        'contents of gitignore',
+      );
+      const project = buildMetaMaskRepository({
+        shortname: 'project',
+        directoryPath: path.join(sandbox.directoryPath, 'project'),
+      });
+
+      const result = await requireGitignore.execute({
+        template,
+        project,
+        pass,
+        fail,
+      });
+
+      expect(result).toStrictEqual({
+        passed: false,
+        failures: [
+          {
+            message: '`.gitignore` does not exist in this project.',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/rules/require-gitignore.ts
+++ b/src/rules/require-gitignore.ts
@@ -1,0 +1,12 @@
+import { buildRule } from './build-rule';
+import { RuleName } from './types';
+import { fileConforms } from '../rule-helpers';
+
+export default buildRule({
+  name: RuleName.RequireGitIgnore,
+  description: 'Is `.gitignore` present, and does it conform?',
+  dependencies: [],
+  execute: async (ruleExecutionArguments) => {
+    return await fileConforms('.gitignore', ruleExecutionArguments);
+  },
+});

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -36,7 +36,9 @@ export enum RuleName {
   RequireValidChangelog = 'require-valid-changelog',
   PackageChangelogDependenciesConform = 'package-changelog-dependencies-conform',
   PackageChangelogScriptsConform = 'package-changelog-scripts-conform',
-  PackageChangelogModuleLintDependenciesConform = 'package-changelog-module-lint-dependencies-conform',
+  RequireEditorConfig = 'require-editorconfig',
+  RequireGitAttributes = 'require-gitattributes',
+  RequireGitIgnore = 'require-gitignore',
 }
 
 export const PackageManifestSchema = type({


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
We want to make sure that for a given project:

.editorconfig is present and matches the same content as in the module template
.gitattributes is present and matches the same content as in the module template
.gitignore is present, and the project's version of the file starts with the template's version

* Fixes #61 