### PR TITLE
error message added in validate changelog

### DIFF
--- a/src/rules/require-valid-changelog.test.ts
+++ b/src/rules/require-valid-changelog.test.ts
@@ -114,13 +114,12 @@ describe('Rule: require-valid-changelog', () => {
       });
       await writeFile(
         path.join(project.directoryPath, 'package.json'),
-        JSON.stringify({ foo: 'bar' }),
+        buildPackageManifestMock({ repository: {} }),
       );
       await writeFile(
         path.join(project.directoryPath, 'CHANGELOG.md'),
         invalidChangelog,
       );
-
       await expect(
         validateChangelog.execute({
           template: buildMetaMaskRepository(),
@@ -129,7 +128,7 @@ describe('Rule: require-valid-changelog', () => {
           fail,
         }),
       ).rejects.toThrow(
-        'The package does not have a well-formed manifest. This is not the fault of the changelog, but this rule requires a valid package manifest.',
+        'Missing `url`.\n The package does not have a well-formed manifest. This is not the fault of the changelog, but this rule requires a valid package manifest.',
       );
     });
   });

--- a/src/rules/require-valid-changelog.test.ts
+++ b/src/rules/require-valid-changelog.test.ts
@@ -128,7 +128,7 @@ describe('Rule: require-valid-changelog', () => {
           fail,
         }),
       ).rejects.toThrow(
-        'Missing `url`.\n The package does not have a well-formed manifest. This is not the fault of the changelog, but this rule requires a valid package manifest.',
+        'Tried to get version from package manifest in order to validate changelog, but manifest is not well-formed (Missing `url`.)',
       );
     });
   });

--- a/src/rules/require-valid-changelog.ts
+++ b/src/rules/require-valid-changelog.ts
@@ -38,7 +38,7 @@ export default buildRule({
         error.code === 'ERR_INVALID_JSON_FILE'
       ) {
         throw new Error(
-          `${error.message}\n The package does not have a well-formed manifest. This is not the fault of the changelog, but this rule requires a valid package manifest.`,
+          `Tried to get version from package manifest in order to validate changelog, but manifest is not well-formed (${error.message}).`,
         );
       } else if (error instanceof ChangelogFormattingError) {
         return fail([

--- a/src/rules/require-valid-changelog.ts
+++ b/src/rules/require-valid-changelog.ts
@@ -2,7 +2,11 @@ import {
   ChangelogFormattingError,
   validateChangelog,
 } from '@metamask/auto-changelog';
-import { getErrorMessage, isErrorWithCode } from '@metamask/utils/node';
+import {
+  getErrorMessage,
+  isErrorWithCode,
+  isErrorWithMessage,
+} from '@metamask/utils/node';
 
 import { buildRule } from './build-rule';
 import { PackageManifestSchema, RuleName } from './types';
@@ -28,9 +32,13 @@ export default buildRule({
       });
       return pass();
     } catch (error) {
-      if (isErrorWithCode(error) && error.code === 'ERR_INVALID_JSON_FILE') {
+      if (
+        isErrorWithCode(error) &&
+        isErrorWithMessage(error) &&
+        error.code === 'ERR_INVALID_JSON_FILE'
+      ) {
         throw new Error(
-          'The package does not have a well-formed manifest. This is not the fault of the changelog, but this rule requires a valid package manifest.',
+          `${error.message}\n The package does not have a well-formed manifest. This is not the fault of the changelog, but this rule requires a valid package manifest.`,
         );
       } else if (error instanceof ChangelogFormattingError) {
         return fail([


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
The error message in case of invalid package manifest in require-valid-changelog was incomplete. The user couldn't understand what is missing from the error message. This change will allow user to understand what is missing in package manifest which triggered invalid package manifest error.

Error message now.
```
Error: The package does not have a well-formed manifest. This is not the fault of the changelog, but this rule requires a valid package manifest.
    at Object.execute (/Users/dck/Workspace/metamask/temp/module-lint/src/rules/require-valid-changelog.ts:40:15)
    at async executeRule (/Users/dck/Workspace/metamask/temp/module-lint/src/execute-rules.ts:198:38)
    at async executeRuleNodes (/Users/dck/Workspace/metamask/temp/module-lint/src/execute-rules.ts:168:7)
    at async executeRule (/Users/dck/Workspace/metamask/temp/module-lint/src/execute-rules.ts:218:9)
    at async executeRuleNodes (/Users/dck/Workspace/metamask/temp/module-lint/src/execute-rules.ts:168:7)
    at async executeRules (/Users/dck/Workspace/metamask/temp/module-lint/src/execute-rules.ts:137:38)
    at async lintProject (/Users/dck/Workspace/metamask/temp/module-lint/src/lint-project.ts:56:35)
    at async /Users/dck/Workspace/metamask/temp/module-lint/src/main.ts:212:14
```

Error message with this change.
```
Error: Missing `exports`; Missing `module`.
 The package does not have a well-formed manifest. This is not the fault of the changelog, but this rule requires a valid package manifest.
    at Object.execute (/Users/dck/Workspace/metamask/temp/module-lint/src/rules/require-valid-changelog.ts:40:15)
    at async executeRule (/Users/dck/Workspace/metamask/temp/module-lint/src/execute-rules.ts:198:38)
    at async executeRuleNodes (/Users/dck/Workspace/metamask/temp/module-lint/src/execute-rules.ts:168:7)
    at async executeRule (/Users/dck/Workspace/metamask/temp/module-lint/src/execute-rules.ts:218:9)
    at async executeRuleNodes (/Users/dck/Workspace/metamask/temp/module-lint/src/execute-rules.ts:168:7)
    at async executeRules (/Users/dck/Workspace/metamask/temp/module-lint/src/execute-rules.ts:137:38)
    at async lintProject (/Users/dck/Workspace/metamask/temp/module-lint/src/lint-project.ts:56:35)
    at async /Users/dck/Workspace/metamask/temp/module-lint/src/main.ts:212:14
```