### PR TITLE
generate module lint report by schedule and post to slack when failed

### DIFF
--- a/.github/workflows/module-lint.yml
+++ b/.github/workflows/module-lint.yml
@@ -6,27 +6,11 @@ on:
     - cron: '10 1 * * 0'
 
 jobs:
-  prepare:
-    name: Prepare
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-      - name: Install Yarn dependencies
-        run: yarn --immutable
-
   module-lint:
     name: Module Lint
     runs-on: ubuntu-latest
-    needs:
-      - prepare
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
         projects:
           [
             { name: 'auto-changelog', team: 'S051YKC9350' },
@@ -36,13 +20,14 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
-      - run: yarn run-tool ${{ matrix.projects.name }}
+      - run: yarn --immutable
+      - name: Run module-lint
+        id: module-lint
+        run: yarn run-tool ${{ matrix.projects.name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Require clean working directory
@@ -54,7 +39,7 @@ jobs:
           fi
       - name: Post module lint report to a slack
         id: slack
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.module-lint.outcome == 'failure' }}
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
         with:
           payload: |

--- a/.github/workflows/module-lint.yml
+++ b/.github/workflows/module-lint.yml
@@ -1,9 +1,9 @@
 name: Module Lint
 
-# runs at minute 5 of the 1st hour of every Sunday
+# runs at minute 10 of the 1st hour of every Sunday
 on:
   schedule:
-    - cron: '05 1 * *  0'
+    - cron: '10 1 * * 0'
 
 jobs:
   prepare:

--- a/.github/workflows/module-lint.yml
+++ b/.github/workflows/module-lint.yml
@@ -1,0 +1,69 @@
+name: Module Lint
+
+# runs at minute 5 of the 1st hour of every Sunday
+on:
+  schedule:
+    - cron: '05 1 * *  0'
+
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - name: Install Yarn dependencies
+        run: yarn --immutable
+
+  module-lint:
+    name: Module Lint
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x, 20.x]
+        projects:
+          [
+            { name: 'auto-changelog', team: 'S051YKC9350' },
+            { name: 'create-release-branch', team: 'S051YKC9350' },
+            { name: 'module-lint', team: 'S051YKC9350' },
+            { name: 'utils', team: 'S051YKC9350' },
+          ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - run: yarn --immutable --immutable-cache
+      - run: yarn run-tool ${{ matrix.projects.name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+      - name: Post module lint report to a slack
+        id: slack
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
+        with:
+          payload: |
+            {
+              "text": "<!subteam^${{ matrix.projects.team }}> Module Lint failed for the `${{ matrix.projects.name }}` repository 😱.\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/|→ Click here> for details!",
+              "icon_url": "https://raw.githubusercontent.com/MetaMask/action-npm-publish/main/robo.png",
+              "username": "MetaMask bot",
+              "channel": "#temp-test-module-lint"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
A module-lint report to be automatically generated once in a week and shared on a slack channel by tagging the team (when failed).

For the purpose of testing, this repo has been [forked](https://github.com/MetaMask/module-lint-fork) and all the changes of this PR are available in the forked repo as well. And right now, it posts to the channel `temp-test-module-lint`. Please feel free to ping me, if you want to be added to this channel to see the scheduled messages posted from github actions to the slack channel.

Here is the screenshot of the report posted to the slack channel.
<img width="634" alt="Screenshot 2024-04-16 at 17 29 39" src="https://github.com/MetaMask/module-lint/assets/45172858/f0f789ac-01e8-4a68-87a5-286b635938a8">

And [click here](https://github.com/MetaMask/module-lint-fork/actions) to see the github action (cron job) in the forked repo.

Fixes #60 