### PR TITLE
Don't abort when rule throws, but continue

### DIFF
--- a/src/build-rule-tree.test.ts
+++ b/src/build-rule-tree.test.ts
@@ -2,6 +2,7 @@ import * as dependencyGraphModule from 'dependency-graph';
 
 import { buildRuleTree } from './build-rule-tree';
 import type { Rule } from './execute-rules';
+import { RuleExecutionStatus } from './execute-rules';
 
 jest.mock('dependency-graph', () => {
   return {
@@ -19,7 +20,7 @@ describe('buildRuleTree', () => {
       dependencies: ['rule-2'],
       execute: async () => {
         return {
-          passed: true,
+          status: RuleExecutionStatus.Passed,
         };
       },
     };
@@ -29,7 +30,7 @@ describe('buildRuleTree', () => {
       dependencies: ['rule-3'],
       execute: async () => {
         return {
-          passed: true,
+          status: RuleExecutionStatus.Passed,
         };
       },
     };
@@ -39,7 +40,7 @@ describe('buildRuleTree', () => {
       dependencies: [],
       execute: async () => {
         return {
-          passed: true,
+          status: RuleExecutionStatus.Passed,
         };
       },
     };
@@ -74,7 +75,7 @@ describe('buildRuleTree', () => {
       dependencies: ['rule-2'],
       execute: async () => {
         return {
-          passed: false,
+          status: RuleExecutionStatus.Failed,
           failures: [{ message: 'Oops' }],
         };
       },
@@ -85,7 +86,7 @@ describe('buildRuleTree', () => {
       dependencies: ['rule-3'],
       execute: async () => {
         return {
-          passed: true,
+          status: RuleExecutionStatus.Passed,
         };
       },
     };
@@ -95,7 +96,7 @@ describe('buildRuleTree', () => {
       dependencies: ['rule-1'],
       execute: async () => {
         return {
-          passed: true,
+          status: RuleExecutionStatus.Passed,
         };
       },
     };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,13 @@ main({
     cachedRepositoriesDirectoryPath: DEFAULT_CACHED_REPOSITORIES_DIRECTORY_PATH,
     defaultProjectNames: DEFAULT_PROJECT_NAMES,
   },
-}).catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+})
+  .then((isSuccessful) => {
+    if (!isSuccessful) {
+      process.exitCode = 1;
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/src/lint-project.test.ts
+++ b/src/lint-project.test.ts
@@ -3,6 +3,7 @@ import { mockDeep } from 'jest-mock-extended';
 
 import type { MetaMaskRepository } from './establish-metamask-repository';
 import type { Rule } from './execute-rules';
+import { RuleExecutionStatus } from './execute-rules';
 import { lintProject } from './lint-project';
 import { FakeOutputLogger } from '../tests/fake-output-logger';
 import { fakeDateOnly, withinSandbox } from '../tests/helpers';
@@ -45,7 +46,7 @@ describe('lintProject', () => {
           execute: async () => {
             jest.setSystemTime(new Date('2023-01-01T00:00:02Z'));
             return {
-              passed: false,
+              status: RuleExecutionStatus.Failed,
               failures: [{ message: 'Oops' }],
             };
           },
@@ -57,7 +58,7 @@ describe('lintProject', () => {
           execute: async () => {
             jest.setSystemTime(new Date('2023-01-01T00:00:01Z'));
             return {
-              passed: true,
+              status: RuleExecutionStatus.Passed,
             };
           },
         },
@@ -83,14 +84,14 @@ describe('lintProject', () => {
               result: {
                 ruleName: 'rule-2',
                 ruleDescription: 'Description for rule 2',
-                passed: true,
+                status: 'passed',
               },
               children: [
                 expect.objectContaining({
                   result: {
                     ruleName: 'rule-1',
                     ruleDescription: 'Description for rule 1',
-                    passed: false,
+                    status: 'failed',
                     failures: [{ message: 'Oops' }],
                   },
                   children: [],

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -198,46 +198,46 @@ describe('main', () => {
 repo-1
 ------
 
- ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
- ✔︎  Does the package have a well-formed manifest (\`package.json\`)?
- ✔︎  Does the \`packageManager\` field in \`package.json\` conform?
- ✔︎  Does the \`engines.node\` field in \`package.json\` conform?
- ✔︎  Do the lint-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the jest-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the test-related \`scripts\` in \`package.json\` conform?
- ✔︎  Do the typescript-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the typescript-related \`scripts\` in \`package.json\` conform?
- ✔︎  Does the \`exports\` field in \`package.json\` conform?
- ✔︎  Does the \`main\` field in \`package.json\` conform?
- ✔︎  Does the \`module\` field in \`package.json\` conform?
- ✔︎  Does the \`types\` field in \`package.json\` conform?
- ✔︎  Does the \`files\` field in \`package.json\` conform?
- ✔︎  Does LavaMoat allow scripts for \`tsup>esbuild\`?
- ✔︎  Do the typedoc-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the typedoc-related \`scripts\` in \`package.json\` conform?
- ✔︎  Do the changelog-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the changelog-related \`scripts\` in \`package.json\` conform?
- ✔︎  Do the lavamoat-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`?
- ✔︎  Is \`README.md\` present?
- ✔︎  Does the README conform by recommending the correct Yarn version to install?
- ✔︎  Does the README conform by recommending node install from nodejs.org?
- ✔︎  Are all of the files for Yarn Modern present, and do they conform?
- ✔︎  Does the README conform by recommending the correct Yarn version to install?
- ✔︎  Does allow scripts conforms to yarn?
- ✔︎  Is the allow-scripts Yarn plugin installed?
- ✔︎  Does the \`src/\` directory exist?
- ✔︎  Is \`.nvmrc\` present, and does it conform?
- ✔︎  Is \`jest.config.js\` present, and does it conform?
- ✔︎  Is \`tsconfig.json\` present, and does it conform?
- ✔︎  Is \`tsconfig.build.json\` present, and does it conform?
- ✔︎  Is \`tsup.config.ts\` present, and does it conform?
- ✔︎  Is \`typedoc.json\` present, and does it conform?
- ✔︎  Is \`CHANGELOG.md\` present?
- ✔︎  Is \`CHANGELOG.md\` well-formatted?
- ✔︎  Is \`.editorconfig\` present, and does it conform?
- ✔︎  Is \`.gitattributes\` present, and does it conform?
- ✔︎  Is \`.gitignore\` present, and does it conform?
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
+- Does the package have a well-formed manifest (\`package.json\`)? ✅
+- Does the \`packageManager\` field in \`package.json\` conform? ✅
+- Does the \`engines.node\` field in \`package.json\` conform? ✅
+- Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the test-related \`scripts\` in \`package.json\` conform? ✅
+- Do the typescript-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the typescript-related \`scripts\` in \`package.json\` conform? ✅
+- Does the \`exports\` field in \`package.json\` conform? ✅
+- Does the \`main\` field in \`package.json\` conform? ✅
+- Does the \`module\` field in \`package.json\` conform? ✅
+- Does the \`types\` field in \`package.json\` conform? ✅
+- Does the \`files\` field in \`package.json\` conform? ✅
+- Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
+- Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
+- Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
+- Do the lavamoat-related \`devDependencies\` in \`package.json\` conform? ✅
+- Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`? ✅
+- Is \`README.md\` present? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
+- Does the README conform by recommending node install from nodejs.org? ✅
+- Are all of the files for Yarn Modern present, and do they conform? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
+- Does allow scripts conforms to yarn? ✅
+- Is the allow-scripts Yarn plugin installed? ✅
+- Does the \`src/\` directory exist? ✅
+- Is \`.nvmrc\` present, and does it conform? ✅
+- Is \`jest.config.js\` present, and does it conform? ✅
+- Is \`tsconfig.json\` present, and does it conform? ✅
+- Is \`tsconfig.build.json\` present, and does it conform? ✅
+- Is \`tsup.config.ts\` present, and does it conform? ✅
+- Is \`typedoc.json\` present, and does it conform? ✅
+- Is \`CHANGELOG.md\` present? ✅
+- Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
 Results:       40 passed, 0 failed, 0 errored, 40 total
 Elapsed time:  0 ms
@@ -246,46 +246,46 @@ Elapsed time:  0 ms
 repo-2
 ------
 
- ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
- ✔︎  Does the package have a well-formed manifest (\`package.json\`)?
- ✔︎  Does the \`packageManager\` field in \`package.json\` conform?
- ✔︎  Does the \`engines.node\` field in \`package.json\` conform?
- ✔︎  Do the lint-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the jest-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the test-related \`scripts\` in \`package.json\` conform?
- ✔︎  Do the typescript-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the typescript-related \`scripts\` in \`package.json\` conform?
- ✔︎  Does the \`exports\` field in \`package.json\` conform?
- ✔︎  Does the \`main\` field in \`package.json\` conform?
- ✔︎  Does the \`module\` field in \`package.json\` conform?
- ✔︎  Does the \`types\` field in \`package.json\` conform?
- ✔︎  Does the \`files\` field in \`package.json\` conform?
- ✔︎  Does LavaMoat allow scripts for \`tsup>esbuild\`?
- ✔︎  Do the typedoc-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the typedoc-related \`scripts\` in \`package.json\` conform?
- ✔︎  Do the changelog-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the changelog-related \`scripts\` in \`package.json\` conform?
- ✔︎  Do the lavamoat-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`?
- ✔︎  Is \`README.md\` present?
- ✔︎  Does the README conform by recommending the correct Yarn version to install?
- ✔︎  Does the README conform by recommending node install from nodejs.org?
- ✔︎  Are all of the files for Yarn Modern present, and do they conform?
- ✔︎  Does the README conform by recommending the correct Yarn version to install?
- ✔︎  Does allow scripts conforms to yarn?
- ✔︎  Is the allow-scripts Yarn plugin installed?
- ✔︎  Does the \`src/\` directory exist?
- ✔︎  Is \`.nvmrc\` present, and does it conform?
- ✔︎  Is \`jest.config.js\` present, and does it conform?
- ✔︎  Is \`tsconfig.json\` present, and does it conform?
- ✔︎  Is \`tsconfig.build.json\` present, and does it conform?
- ✔︎  Is \`tsup.config.ts\` present, and does it conform?
- ✔︎  Is \`typedoc.json\` present, and does it conform?
- ✔︎  Is \`CHANGELOG.md\` present?
- ✔︎  Is \`CHANGELOG.md\` well-formatted?
- ✔︎  Is \`.editorconfig\` present, and does it conform?
- ✔︎  Is \`.gitattributes\` present, and does it conform?
- ✔︎  Is \`.gitignore\` present, and does it conform?
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
+- Does the package have a well-formed manifest (\`package.json\`)? ✅
+- Does the \`packageManager\` field in \`package.json\` conform? ✅
+- Does the \`engines.node\` field in \`package.json\` conform? ✅
+- Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the test-related \`scripts\` in \`package.json\` conform? ✅
+- Do the typescript-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the typescript-related \`scripts\` in \`package.json\` conform? ✅
+- Does the \`exports\` field in \`package.json\` conform? ✅
+- Does the \`main\` field in \`package.json\` conform? ✅
+- Does the \`module\` field in \`package.json\` conform? ✅
+- Does the \`types\` field in \`package.json\` conform? ✅
+- Does the \`files\` field in \`package.json\` conform? ✅
+- Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
+- Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
+- Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
+- Do the lavamoat-related \`devDependencies\` in \`package.json\` conform? ✅
+- Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`? ✅
+- Is \`README.md\` present? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
+- Does the README conform by recommending node install from nodejs.org? ✅
+- Are all of the files for Yarn Modern present, and do they conform? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
+- Does allow scripts conforms to yarn? ✅
+- Is the allow-scripts Yarn plugin installed? ✅
+- Does the \`src/\` directory exist? ✅
+- Is \`.nvmrc\` present, and does it conform? ✅
+- Is \`jest.config.js\` present, and does it conform? ✅
+- Is \`tsconfig.json\` present, and does it conform? ✅
+- Is \`tsconfig.build.json\` present, and does it conform? ✅
+- Is \`tsup.config.ts\` present, and does it conform? ✅
+- Is \`typedoc.json\` present, and does it conform? ✅
+- Is \`CHANGELOG.md\` present? ✅
+- Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
 Results:       40 passed, 0 failed, 0 errored, 40 total
 Elapsed time:  0 ms
@@ -333,38 +333,38 @@ Elapsed time:  0 ms
 repo-1
 ------
 
- ✘  Is the classic Yarn config file (\`.yarnrc\`) absent?
-    - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
- ✘  Does the package have a well-formed manifest (\`package.json\`)?
-    - \`package.json\` does not exist in this project.
- ✘  Is \`README.md\` present?
-    - \`README.md\` does not exist in this project.
- ✘  Are all of the files for Yarn Modern present, and do they conform?
-    - \`.yarnrc.yml\` does not exist in this project.
-    - \`.yarn/releases/\` does not exist in this project.
-    - \`.yarn/plugins/\` does not exist in this project.
- ✘  Does the \`src/\` directory exist?
-    - \`src/\` does not exist in this project.
- ✘  Is \`.nvmrc\` present, and does it conform?
-    - \`.nvmrc\` does not exist in this project.
- ✘  Is \`jest.config.js\` present, and does it conform?
-    - \`jest.config.js\` does not exist in this project.
- ✘  Is \`tsconfig.json\` present, and does it conform?
-    - \`tsconfig.json\` does not exist in this project.
- ✘  Is \`tsconfig.build.json\` present, and does it conform?
-    - \`tsconfig.build.json\` does not exist in this project.
- ✘  Is \`tsup.config.ts\` present, and does it conform?
-    - \`tsup.config.ts\` does not exist in this project.
- ✘  Is \`typedoc.json\` present, and does it conform?
-    - \`typedoc.json\` does not exist in this project.
- ✘  Is \`CHANGELOG.md\` present?
-    - \`CHANGELOG.md\` does not exist in this project.
- ✘  Is \`.editorconfig\` present, and does it conform?
-    - \`.editorconfig\` does not exist in this project.
- ✘  Is \`.gitattributes\` present, and does it conform?
-    - \`.gitattributes\` does not exist in this project.
- ✘  Is \`.gitignore\` present, and does it conform?
-    - \`.gitignore\` does not exist in this project.
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ❌
+  - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
+- Does the package have a well-formed manifest (\`package.json\`)? ❌
+  - \`package.json\` does not exist in this project.
+- Is \`README.md\` present? ❌
+  - \`README.md\` does not exist in this project.
+- Are all of the files for Yarn Modern present, and do they conform? ❌
+  - \`.yarnrc.yml\` does not exist in this project.
+  - \`.yarn/releases/\` does not exist in this project.
+  - \`.yarn/plugins/\` does not exist in this project.
+- Does the \`src/\` directory exist? ❌
+  - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and does it conform? ❌
+  - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
+- Is \`tsconfig.json\` present, and does it conform? ❌
+  - \`tsconfig.json\` does not exist in this project.
+- Is \`tsconfig.build.json\` present, and does it conform? ❌
+  - \`tsconfig.build.json\` does not exist in this project.
+- Is \`tsup.config.ts\` present, and does it conform? ❌
+  - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ❌
+  - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
 Results:       0 passed, 15 failed, 0 errored, 15 total
 Elapsed time:  0 ms
@@ -373,38 +373,38 @@ Elapsed time:  0 ms
 repo-2
 ------
 
- ✘  Is the classic Yarn config file (\`.yarnrc\`) absent?
-    - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
- ✘  Does the package have a well-formed manifest (\`package.json\`)?
-    - \`package.json\` does not exist in this project.
- ✘  Is \`README.md\` present?
-    - \`README.md\` does not exist in this project.
- ✘  Are all of the files for Yarn Modern present, and do they conform?
-    - \`.yarnrc.yml\` does not exist in this project.
-    - \`.yarn/releases/\` does not exist in this project.
-    - \`.yarn/plugins/\` does not exist in this project.
- ✘  Does the \`src/\` directory exist?
-    - \`src/\` does not exist in this project.
- ✘  Is \`.nvmrc\` present, and does it conform?
-    - \`.nvmrc\` does not exist in this project.
- ✘  Is \`jest.config.js\` present, and does it conform?
-    - \`jest.config.js\` does not exist in this project.
- ✘  Is \`tsconfig.json\` present, and does it conform?
-    - \`tsconfig.json\` does not exist in this project.
- ✘  Is \`tsconfig.build.json\` present, and does it conform?
-    - \`tsconfig.build.json\` does not exist in this project.
- ✘  Is \`tsup.config.ts\` present, and does it conform?
-    - \`tsup.config.ts\` does not exist in this project.
- ✘  Is \`typedoc.json\` present, and does it conform?
-    - \`typedoc.json\` does not exist in this project.
- ✘  Is \`CHANGELOG.md\` present?
-    - \`CHANGELOG.md\` does not exist in this project.
- ✘  Is \`.editorconfig\` present, and does it conform?
-    - \`.editorconfig\` does not exist in this project.
- ✘  Is \`.gitattributes\` present, and does it conform?
-    - \`.gitattributes\` does not exist in this project.
- ✘  Is \`.gitignore\` present, and does it conform?
-    - \`.gitignore\` does not exist in this project.
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ❌
+  - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
+- Does the package have a well-formed manifest (\`package.json\`)? ❌
+  - \`package.json\` does not exist in this project.
+- Is \`README.md\` present? ❌
+  - \`README.md\` does not exist in this project.
+- Are all of the files for Yarn Modern present, and do they conform? ❌
+  - \`.yarnrc.yml\` does not exist in this project.
+  - \`.yarn/releases/\` does not exist in this project.
+  - \`.yarn/plugins/\` does not exist in this project.
+- Does the \`src/\` directory exist? ❌
+  - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and does it conform? ❌
+  - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
+- Is \`tsconfig.json\` present, and does it conform? ❌
+  - \`tsconfig.json\` does not exist in this project.
+- Is \`tsconfig.build.json\` present, and does it conform? ❌
+  - \`tsconfig.build.json\` does not exist in this project.
+- Is \`tsup.config.ts\` present, and does it conform? ❌
+  - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ❌
+  - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
 Results:       0 passed, 15 failed, 0 errored, 15 total
 Elapsed time:  0 ms
@@ -455,38 +455,38 @@ Elapsed time:  0 ms
 repo-1
 ------
 
- ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
- ✘  Does the package have a well-formed manifest (\`package.json\`)?
-    - \`package.json\` does not exist in this project.
- ✘  Is \`README.md\` present?
-    - \`README.md\` does not exist in this project.
- ✘  Are all of the files for Yarn Modern present, and do they conform?
-    - \`.yarnrc.yml\` does not exist in this project.
-    - \`.yarn/releases/\` does not exist in this project.
-    - \`.yarn/plugins/\` does not exist in this project.
- ✘  Does the \`src/\` directory exist?
-    - \`src/\` does not exist in this project.
- ✘  Is \`.nvmrc\` present, and does it conform?
-    - \`.nvmrc\` does not exist in this project.
- ✘  Is \`jest.config.js\` present, and does it conform?
-    - \`jest.config.js\` does not exist in this project.
- ✘  Is \`tsconfig.json\` present, and does it conform?
-    - \`tsconfig.json\` does not exist in this project.
- ✘  Is \`tsconfig.build.json\` present, and does it conform?
-    - \`tsconfig.build.json\` does not exist in this project.
- ✘  Is \`tsup.config.ts\` present, and does it conform?
-    - \`tsup.config.ts\` does not exist in this project.
- ✘  Is \`typedoc.json\` present, and does it conform?
-    - \`typedoc.json\` does not exist in this project.
- ✔︎  Is \`CHANGELOG.md\` present?
- ?  Is \`CHANGELOG.md\` well-formatted?
-    - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-1/package.json'.
- ✘  Is \`.editorconfig\` present, and does it conform?
-    - \`.editorconfig\` does not exist in this project.
- ✘  Is \`.gitattributes\` present, and does it conform?
-    - \`.gitattributes\` does not exist in this project.
- ✘  Is \`.gitignore\` present, and does it conform?
-    - \`.gitignore\` does not exist in this project.
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
+- Does the package have a well-formed manifest (\`package.json\`)? ❌
+  - \`package.json\` does not exist in this project.
+- Is \`README.md\` present? ❌
+  - \`README.md\` does not exist in this project.
+- Are all of the files for Yarn Modern present, and do they conform? ❌
+  - \`.yarnrc.yml\` does not exist in this project.
+  - \`.yarn/releases/\` does not exist in this project.
+  - \`.yarn/plugins/\` does not exist in this project.
+- Does the \`src/\` directory exist? ❌
+  - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and does it conform? ❌
+  - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
+- Is \`tsconfig.json\` present, and does it conform? ❌
+  - \`tsconfig.json\` does not exist in this project.
+- Is \`tsconfig.build.json\` present, and does it conform? ❌
+  - \`tsconfig.build.json\` does not exist in this project.
+- Is \`tsup.config.ts\` present, and does it conform? ❌
+  - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ✅
+- Is \`CHANGELOG.md\` well-formatted? ⚠️
+  - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-1/package.json'.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
 Results:       2 passed, 13 failed, 1 errored, 16 total
 Elapsed time:  0 ms
@@ -495,38 +495,38 @@ Elapsed time:  0 ms
 repo-2
 ------
 
- ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
- ✘  Does the package have a well-formed manifest (\`package.json\`)?
-    - \`package.json\` does not exist in this project.
- ✘  Is \`README.md\` present?
-    - \`README.md\` does not exist in this project.
- ✘  Are all of the files for Yarn Modern present, and do they conform?
-    - \`.yarnrc.yml\` does not exist in this project.
-    - \`.yarn/releases/\` does not exist in this project.
-    - \`.yarn/plugins/\` does not exist in this project.
- ✘  Does the \`src/\` directory exist?
-    - \`src/\` does not exist in this project.
- ✘  Is \`.nvmrc\` present, and does it conform?
-    - \`.nvmrc\` does not exist in this project.
- ✘  Is \`jest.config.js\` present, and does it conform?
-    - \`jest.config.js\` does not exist in this project.
- ✘  Is \`tsconfig.json\` present, and does it conform?
-    - \`tsconfig.json\` does not exist in this project.
- ✘  Is \`tsconfig.build.json\` present, and does it conform?
-    - \`tsconfig.build.json\` does not exist in this project.
- ✘  Is \`tsup.config.ts\` present, and does it conform?
-    - \`tsup.config.ts\` does not exist in this project.
- ✘  Is \`typedoc.json\` present, and does it conform?
-    - \`typedoc.json\` does not exist in this project.
- ✔︎  Is \`CHANGELOG.md\` present?
- ?  Is \`CHANGELOG.md\` well-formatted?
-    - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-2/package.json'.
- ✘  Is \`.editorconfig\` present, and does it conform?
-    - \`.editorconfig\` does not exist in this project.
- ✘  Is \`.gitattributes\` present, and does it conform?
-    - \`.gitattributes\` does not exist in this project.
- ✘  Is \`.gitignore\` present, and does it conform?
-    - \`.gitignore\` does not exist in this project.
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
+- Does the package have a well-formed manifest (\`package.json\`)? ❌
+  - \`package.json\` does not exist in this project.
+- Is \`README.md\` present? ❌
+  - \`README.md\` does not exist in this project.
+- Are all of the files for Yarn Modern present, and do they conform? ❌
+  - \`.yarnrc.yml\` does not exist in this project.
+  - \`.yarn/releases/\` does not exist in this project.
+  - \`.yarn/plugins/\` does not exist in this project.
+- Does the \`src/\` directory exist? ❌
+  - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and does it conform? ❌
+  - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
+- Is \`tsconfig.json\` present, and does it conform? ❌
+  - \`tsconfig.json\` does not exist in this project.
+- Is \`tsconfig.build.json\` present, and does it conform? ❌
+  - \`tsconfig.build.json\` does not exist in this project.
+- Is \`tsup.config.ts\` present, and does it conform? ❌
+  - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ✅
+- Is \`CHANGELOG.md\` well-formatted? ⚠️
+  - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-2/package.json'.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
 Results:       2 passed, 13 failed, 1 errored, 16 total
 Elapsed time:  0 ms
@@ -581,37 +581,37 @@ Cloning repository MetaMask/repo-2, please wait...
 repo-2
 ------
 
- ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
- ✘  Does the package have a well-formed manifest (\`package.json\`)?
-    - \`package.json\` does not exist in this project.
- ✘  Is \`README.md\` present?
-    - \`README.md\` does not exist in this project.
- ✘  Are all of the files for Yarn Modern present, and do they conform?
-    - \`.yarnrc.yml\` does not exist in this project.
-    - \`.yarn/releases/\` does not exist in this project.
-    - \`.yarn/plugins/\` does not exist in this project.
- ✘  Does the \`src/\` directory exist?
-    - \`src/\` does not exist in this project.
- ✘  Is \`.nvmrc\` present, and does it conform?
-    - \`.nvmrc\` does not exist in this project.
- ✘  Is \`jest.config.js\` present, and does it conform?
-    - \`jest.config.js\` does not exist in this project.
- ✘  Is \`tsconfig.json\` present, and does it conform?
-    - \`tsconfig.json\` does not exist in this project.
- ✘  Is \`tsconfig.build.json\` present, and does it conform?
-    - \`tsconfig.build.json\` does not exist in this project.
- ✘  Is \`tsup.config.ts\` present, and does it conform?
-    - \`tsup.config.ts\` does not exist in this project.
- ✘  Is \`typedoc.json\` present, and does it conform?
-    - \`typedoc.json\` does not exist in this project.
- ✘  Is \`CHANGELOG.md\` present?
-    - \`CHANGELOG.md\` does not exist in this project.
- ✘  Is \`.editorconfig\` present, and does it conform?
-    - \`.editorconfig\` does not exist in this project.
- ✘  Is \`.gitattributes\` present, and does it conform?
-    - \`.gitattributes\` does not exist in this project.
- ✘  Is \`.gitignore\` present, and does it conform?
-    - \`.gitignore\` does not exist in this project.
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
+- Does the package have a well-formed manifest (\`package.json\`)? ❌
+  - \`package.json\` does not exist in this project.
+- Is \`README.md\` present? ❌
+  - \`README.md\` does not exist in this project.
+- Are all of the files for Yarn Modern present, and do they conform? ❌
+  - \`.yarnrc.yml\` does not exist in this project.
+  - \`.yarn/releases/\` does not exist in this project.
+  - \`.yarn/plugins/\` does not exist in this project.
+- Does the \`src/\` directory exist? ❌
+  - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and does it conform? ❌
+  - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
+- Is \`tsconfig.json\` present, and does it conform? ❌
+  - \`tsconfig.json\` does not exist in this project.
+- Is \`tsconfig.build.json\` present, and does it conform? ❌
+  - \`tsconfig.build.json\` does not exist in this project.
+- Is \`tsup.config.ts\` present, and does it conform? ❌
+  - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ❌
+  - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
 Results:       1 passed, 14 failed, 0 errored, 15 total
 Elapsed time:  0 ms
@@ -780,46 +780,46 @@ Elapsed time:  0 ms
 repo-1
 ------
 
- ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
- ✔︎  Does the package have a well-formed manifest (\`package.json\`)?
- ✔︎  Does the \`packageManager\` field in \`package.json\` conform?
- ✔︎  Does the \`engines.node\` field in \`package.json\` conform?
- ✔︎  Do the lint-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the jest-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the test-related \`scripts\` in \`package.json\` conform?
- ✔︎  Do the typescript-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the typescript-related \`scripts\` in \`package.json\` conform?
- ✔︎  Does the \`exports\` field in \`package.json\` conform?
- ✔︎  Does the \`main\` field in \`package.json\` conform?
- ✔︎  Does the \`module\` field in \`package.json\` conform?
- ✔︎  Does the \`types\` field in \`package.json\` conform?
- ✔︎  Does the \`files\` field in \`package.json\` conform?
- ✔︎  Does LavaMoat allow scripts for \`tsup>esbuild\`?
- ✔︎  Do the typedoc-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the typedoc-related \`scripts\` in \`package.json\` conform?
- ✔︎  Do the changelog-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the changelog-related \`scripts\` in \`package.json\` conform?
- ✔︎  Do the lavamoat-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`?
- ✔︎  Is \`README.md\` present?
- ✔︎  Does the README conform by recommending the correct Yarn version to install?
- ✔︎  Does the README conform by recommending node install from nodejs.org?
- ✔︎  Are all of the files for Yarn Modern present, and do they conform?
- ✔︎  Does the README conform by recommending the correct Yarn version to install?
- ✔︎  Does allow scripts conforms to yarn?
- ✔︎  Is the allow-scripts Yarn plugin installed?
- ✔︎  Does the \`src/\` directory exist?
- ✔︎  Is \`.nvmrc\` present, and does it conform?
- ✔︎  Is \`jest.config.js\` present, and does it conform?
- ✔︎  Is \`tsconfig.json\` present, and does it conform?
- ✔︎  Is \`tsconfig.build.json\` present, and does it conform?
- ✔︎  Is \`tsup.config.ts\` present, and does it conform?
- ✔︎  Is \`typedoc.json\` present, and does it conform?
- ✔︎  Is \`CHANGELOG.md\` present?
- ✔︎  Is \`CHANGELOG.md\` well-formatted?
- ✔︎  Is \`.editorconfig\` present, and does it conform?
- ✔︎  Is \`.gitattributes\` present, and does it conform?
- ✔︎  Is \`.gitignore\` present, and does it conform?
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
+- Does the package have a well-formed manifest (\`package.json\`)? ✅
+- Does the \`packageManager\` field in \`package.json\` conform? ✅
+- Does the \`engines.node\` field in \`package.json\` conform? ✅
+- Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the test-related \`scripts\` in \`package.json\` conform? ✅
+- Do the typescript-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the typescript-related \`scripts\` in \`package.json\` conform? ✅
+- Does the \`exports\` field in \`package.json\` conform? ✅
+- Does the \`main\` field in \`package.json\` conform? ✅
+- Does the \`module\` field in \`package.json\` conform? ✅
+- Does the \`types\` field in \`package.json\` conform? ✅
+- Does the \`files\` field in \`package.json\` conform? ✅
+- Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
+- Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
+- Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
+- Do the lavamoat-related \`devDependencies\` in \`package.json\` conform? ✅
+- Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`? ✅
+- Is \`README.md\` present? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
+- Does the README conform by recommending node install from nodejs.org? ✅
+- Are all of the files for Yarn Modern present, and do they conform? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
+- Does allow scripts conforms to yarn? ✅
+- Is the allow-scripts Yarn plugin installed? ✅
+- Does the \`src/\` directory exist? ✅
+- Is \`.nvmrc\` present, and does it conform? ✅
+- Is \`jest.config.js\` present, and does it conform? ✅
+- Is \`tsconfig.json\` present, and does it conform? ✅
+- Is \`tsconfig.build.json\` present, and does it conform? ✅
+- Is \`tsup.config.ts\` present, and does it conform? ✅
+- Is \`typedoc.json\` present, and does it conform? ✅
+- Is \`CHANGELOG.md\` present? ✅
+- Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
 Results:       40 passed, 0 failed, 0 errored, 40 total
 Elapsed time:  0 ms
@@ -828,46 +828,46 @@ Elapsed time:  0 ms
 repo-2
 ------
 
- ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
- ✔︎  Does the package have a well-formed manifest (\`package.json\`)?
- ✔︎  Does the \`packageManager\` field in \`package.json\` conform?
- ✔︎  Does the \`engines.node\` field in \`package.json\` conform?
- ✔︎  Do the lint-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the jest-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the test-related \`scripts\` in \`package.json\` conform?
- ✔︎  Do the typescript-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the typescript-related \`scripts\` in \`package.json\` conform?
- ✔︎  Does the \`exports\` field in \`package.json\` conform?
- ✔︎  Does the \`main\` field in \`package.json\` conform?
- ✔︎  Does the \`module\` field in \`package.json\` conform?
- ✔︎  Does the \`types\` field in \`package.json\` conform?
- ✔︎  Does the \`files\` field in \`package.json\` conform?
- ✔︎  Does LavaMoat allow scripts for \`tsup>esbuild\`?
- ✔︎  Do the typedoc-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the typedoc-related \`scripts\` in \`package.json\` conform?
- ✔︎  Do the changelog-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Do the changelog-related \`scripts\` in \`package.json\` conform?
- ✔︎  Do the lavamoat-related \`devDependencies\` in \`package.json\` conform?
- ✔︎  Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`?
- ✔︎  Is \`README.md\` present?
- ✔︎  Does the README conform by recommending the correct Yarn version to install?
- ✔︎  Does the README conform by recommending node install from nodejs.org?
- ✔︎  Are all of the files for Yarn Modern present, and do they conform?
- ✔︎  Does the README conform by recommending the correct Yarn version to install?
- ✔︎  Does allow scripts conforms to yarn?
- ✔︎  Is the allow-scripts Yarn plugin installed?
- ✔︎  Does the \`src/\` directory exist?
- ✔︎  Is \`.nvmrc\` present, and does it conform?
- ✔︎  Is \`jest.config.js\` present, and does it conform?
- ✔︎  Is \`tsconfig.json\` present, and does it conform?
- ✔︎  Is \`tsconfig.build.json\` present, and does it conform?
- ✔︎  Is \`tsup.config.ts\` present, and does it conform?
- ✔︎  Is \`typedoc.json\` present, and does it conform?
- ✔︎  Is \`CHANGELOG.md\` present?
- ✔︎  Is \`CHANGELOG.md\` well-formatted?
- ✔︎  Is \`.editorconfig\` present, and does it conform?
- ✔︎  Is \`.gitattributes\` present, and does it conform?
- ✔︎  Is \`.gitignore\` present, and does it conform?
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
+- Does the package have a well-formed manifest (\`package.json\`)? ✅
+- Does the \`packageManager\` field in \`package.json\` conform? ✅
+- Does the \`engines.node\` field in \`package.json\` conform? ✅
+- Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the test-related \`scripts\` in \`package.json\` conform? ✅
+- Do the typescript-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the typescript-related \`scripts\` in \`package.json\` conform? ✅
+- Does the \`exports\` field in \`package.json\` conform? ✅
+- Does the \`main\` field in \`package.json\` conform? ✅
+- Does the \`module\` field in \`package.json\` conform? ✅
+- Does the \`types\` field in \`package.json\` conform? ✅
+- Does the \`files\` field in \`package.json\` conform? ✅
+- Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
+- Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
+- Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
+- Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
+- Do the lavamoat-related \`devDependencies\` in \`package.json\` conform? ✅
+- Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`? ✅
+- Is \`README.md\` present? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
+- Does the README conform by recommending node install from nodejs.org? ✅
+- Are all of the files for Yarn Modern present, and do they conform? ✅
+- Does the README conform by recommending the correct Yarn version to install? ✅
+- Does allow scripts conforms to yarn? ✅
+- Is the allow-scripts Yarn plugin installed? ✅
+- Does the \`src/\` directory exist? ✅
+- Is \`.nvmrc\` present, and does it conform? ✅
+- Is \`jest.config.js\` present, and does it conform? ✅
+- Is \`tsconfig.json\` present, and does it conform? ✅
+- Is \`tsconfig.build.json\` present, and does it conform? ✅
+- Is \`tsup.config.ts\` present, and does it conform? ✅
+- Is \`typedoc.json\` present, and does it conform? ✅
+- Is \`CHANGELOG.md\` present? ✅
+- Is \`CHANGELOG.md\` well-formatted? ✅
+- Is \`.editorconfig\` present, and does it conform? ✅
+- Is \`.gitattributes\` present, and does it conform? ✅
+- Is \`.gitignore\` present, and does it conform? ✅
 
 Results:       40 passed, 0 failed, 0 errored, 40 total
 Elapsed time:  0 ms
@@ -915,38 +915,38 @@ Elapsed time:  0 ms
 repo-1
 ------
 
- ✘  Is the classic Yarn config file (\`.yarnrc\`) absent?
-    - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
- ✘  Does the package have a well-formed manifest (\`package.json\`)?
-    - \`package.json\` does not exist in this project.
- ✘  Is \`README.md\` present?
-    - \`README.md\` does not exist in this project.
- ✘  Are all of the files for Yarn Modern present, and do they conform?
-    - \`.yarnrc.yml\` does not exist in this project.
-    - \`.yarn/releases/\` does not exist in this project.
-    - \`.yarn/plugins/\` does not exist in this project.
- ✘  Does the \`src/\` directory exist?
-    - \`src/\` does not exist in this project.
- ✘  Is \`.nvmrc\` present, and does it conform?
-    - \`.nvmrc\` does not exist in this project.
- ✘  Is \`jest.config.js\` present, and does it conform?
-    - \`jest.config.js\` does not exist in this project.
- ✘  Is \`tsconfig.json\` present, and does it conform?
-    - \`tsconfig.json\` does not exist in this project.
- ✘  Is \`tsconfig.build.json\` present, and does it conform?
-    - \`tsconfig.build.json\` does not exist in this project.
- ✘  Is \`tsup.config.ts\` present, and does it conform?
-    - \`tsup.config.ts\` does not exist in this project.
- ✘  Is \`typedoc.json\` present, and does it conform?
-    - \`typedoc.json\` does not exist in this project.
- ✘  Is \`CHANGELOG.md\` present?
-    - \`CHANGELOG.md\` does not exist in this project.
- ✘  Is \`.editorconfig\` present, and does it conform?
-    - \`.editorconfig\` does not exist in this project.
- ✘  Is \`.gitattributes\` present, and does it conform?
-    - \`.gitattributes\` does not exist in this project.
- ✘  Is \`.gitignore\` present, and does it conform?
-    - \`.gitignore\` does not exist in this project.
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ❌
+  - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
+- Does the package have a well-formed manifest (\`package.json\`)? ❌
+  - \`package.json\` does not exist in this project.
+- Is \`README.md\` present? ❌
+  - \`README.md\` does not exist in this project.
+- Are all of the files for Yarn Modern present, and do they conform? ❌
+  - \`.yarnrc.yml\` does not exist in this project.
+  - \`.yarn/releases/\` does not exist in this project.
+  - \`.yarn/plugins/\` does not exist in this project.
+- Does the \`src/\` directory exist? ❌
+  - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and does it conform? ❌
+  - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
+- Is \`tsconfig.json\` present, and does it conform? ❌
+  - \`tsconfig.json\` does not exist in this project.
+- Is \`tsconfig.build.json\` present, and does it conform? ❌
+  - \`tsconfig.build.json\` does not exist in this project.
+- Is \`tsup.config.ts\` present, and does it conform? ❌
+  - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ❌
+  - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
 Results:       0 passed, 15 failed, 0 errored, 15 total
 Elapsed time:  0 ms
@@ -955,38 +955,38 @@ Elapsed time:  0 ms
 repo-2
 ------
 
- ✘  Is the classic Yarn config file (\`.yarnrc\`) absent?
-    - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
- ✘  Does the package have a well-formed manifest (\`package.json\`)?
-    - \`package.json\` does not exist in this project.
- ✘  Is \`README.md\` present?
-    - \`README.md\` does not exist in this project.
- ✘  Are all of the files for Yarn Modern present, and do they conform?
-    - \`.yarnrc.yml\` does not exist in this project.
-    - \`.yarn/releases/\` does not exist in this project.
-    - \`.yarn/plugins/\` does not exist in this project.
- ✘  Does the \`src/\` directory exist?
-    - \`src/\` does not exist in this project.
- ✘  Is \`.nvmrc\` present, and does it conform?
-    - \`.nvmrc\` does not exist in this project.
- ✘  Is \`jest.config.js\` present, and does it conform?
-    - \`jest.config.js\` does not exist in this project.
- ✘  Is \`tsconfig.json\` present, and does it conform?
-    - \`tsconfig.json\` does not exist in this project.
- ✘  Is \`tsconfig.build.json\` present, and does it conform?
-    - \`tsconfig.build.json\` does not exist in this project.
- ✘  Is \`tsup.config.ts\` present, and does it conform?
-    - \`tsup.config.ts\` does not exist in this project.
- ✘  Is \`typedoc.json\` present, and does it conform?
-    - \`typedoc.json\` does not exist in this project.
- ✘  Is \`CHANGELOG.md\` present?
-    - \`CHANGELOG.md\` does not exist in this project.
- ✘  Is \`.editorconfig\` present, and does it conform?
-    - \`.editorconfig\` does not exist in this project.
- ✘  Is \`.gitattributes\` present, and does it conform?
-    - \`.gitattributes\` does not exist in this project.
- ✘  Is \`.gitignore\` present, and does it conform?
-    - \`.gitignore\` does not exist in this project.
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ❌
+  - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
+- Does the package have a well-formed manifest (\`package.json\`)? ❌
+  - \`package.json\` does not exist in this project.
+- Is \`README.md\` present? ❌
+  - \`README.md\` does not exist in this project.
+- Are all of the files for Yarn Modern present, and do they conform? ❌
+  - \`.yarnrc.yml\` does not exist in this project.
+  - \`.yarn/releases/\` does not exist in this project.
+  - \`.yarn/plugins/\` does not exist in this project.
+- Does the \`src/\` directory exist? ❌
+  - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and does it conform? ❌
+  - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
+- Is \`tsconfig.json\` present, and does it conform? ❌
+  - \`tsconfig.json\` does not exist in this project.
+- Is \`tsconfig.build.json\` present, and does it conform? ❌
+  - \`tsconfig.build.json\` does not exist in this project.
+- Is \`tsup.config.ts\` present, and does it conform? ❌
+  - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ❌
+  - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
 Results:       0 passed, 15 failed, 0 errored, 15 total
 Elapsed time:  0 ms
@@ -1037,38 +1037,38 @@ Elapsed time:  0 ms
 repo-1
 ------
 
- ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
- ✘  Does the package have a well-formed manifest (\`package.json\`)?
-    - \`package.json\` does not exist in this project.
- ✘  Is \`README.md\` present?
-    - \`README.md\` does not exist in this project.
- ✘  Are all of the files for Yarn Modern present, and do they conform?
-    - \`.yarnrc.yml\` does not exist in this project.
-    - \`.yarn/releases/\` does not exist in this project.
-    - \`.yarn/plugins/\` does not exist in this project.
- ✘  Does the \`src/\` directory exist?
-    - \`src/\` does not exist in this project.
- ✘  Is \`.nvmrc\` present, and does it conform?
-    - \`.nvmrc\` does not exist in this project.
- ✘  Is \`jest.config.js\` present, and does it conform?
-    - \`jest.config.js\` does not exist in this project.
- ✘  Is \`tsconfig.json\` present, and does it conform?
-    - \`tsconfig.json\` does not exist in this project.
- ✘  Is \`tsconfig.build.json\` present, and does it conform?
-    - \`tsconfig.build.json\` does not exist in this project.
- ✘  Is \`tsup.config.ts\` present, and does it conform?
-    - \`tsup.config.ts\` does not exist in this project.
- ✘  Is \`typedoc.json\` present, and does it conform?
-    - \`typedoc.json\` does not exist in this project.
- ✔︎  Is \`CHANGELOG.md\` present?
- ?  Is \`CHANGELOG.md\` well-formatted?
-    - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-1/package.json'.
- ✘  Is \`.editorconfig\` present, and does it conform?
-    - \`.editorconfig\` does not exist in this project.
- ✘  Is \`.gitattributes\` present, and does it conform?
-    - \`.gitattributes\` does not exist in this project.
- ✘  Is \`.gitignore\` present, and does it conform?
-    - \`.gitignore\` does not exist in this project.
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
+- Does the package have a well-formed manifest (\`package.json\`)? ❌
+  - \`package.json\` does not exist in this project.
+- Is \`README.md\` present? ❌
+  - \`README.md\` does not exist in this project.
+- Are all of the files for Yarn Modern present, and do they conform? ❌
+  - \`.yarnrc.yml\` does not exist in this project.
+  - \`.yarn/releases/\` does not exist in this project.
+  - \`.yarn/plugins/\` does not exist in this project.
+- Does the \`src/\` directory exist? ❌
+  - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and does it conform? ❌
+  - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
+- Is \`tsconfig.json\` present, and does it conform? ❌
+  - \`tsconfig.json\` does not exist in this project.
+- Is \`tsconfig.build.json\` present, and does it conform? ❌
+  - \`tsconfig.build.json\` does not exist in this project.
+- Is \`tsup.config.ts\` present, and does it conform? ❌
+  - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ✅
+- Is \`CHANGELOG.md\` well-formatted? ⚠️
+  - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-1/package.json'.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
 Results:       2 passed, 13 failed, 1 errored, 16 total
 Elapsed time:  0 ms
@@ -1077,38 +1077,38 @@ Elapsed time:  0 ms
 repo-2
 ------
 
- ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
- ✘  Does the package have a well-formed manifest (\`package.json\`)?
-    - \`package.json\` does not exist in this project.
- ✘  Is \`README.md\` present?
-    - \`README.md\` does not exist in this project.
- ✘  Are all of the files for Yarn Modern present, and do they conform?
-    - \`.yarnrc.yml\` does not exist in this project.
-    - \`.yarn/releases/\` does not exist in this project.
-    - \`.yarn/plugins/\` does not exist in this project.
- ✘  Does the \`src/\` directory exist?
-    - \`src/\` does not exist in this project.
- ✘  Is \`.nvmrc\` present, and does it conform?
-    - \`.nvmrc\` does not exist in this project.
- ✘  Is \`jest.config.js\` present, and does it conform?
-    - \`jest.config.js\` does not exist in this project.
- ✘  Is \`tsconfig.json\` present, and does it conform?
-    - \`tsconfig.json\` does not exist in this project.
- ✘  Is \`tsconfig.build.json\` present, and does it conform?
-    - \`tsconfig.build.json\` does not exist in this project.
- ✘  Is \`tsup.config.ts\` present, and does it conform?
-    - \`tsup.config.ts\` does not exist in this project.
- ✘  Is \`typedoc.json\` present, and does it conform?
-    - \`typedoc.json\` does not exist in this project.
- ✔︎  Is \`CHANGELOG.md\` present?
- ?  Is \`CHANGELOG.md\` well-formatted?
-    - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-2/package.json'.
- ✘  Is \`.editorconfig\` present, and does it conform?
-    - \`.editorconfig\` does not exist in this project.
- ✘  Is \`.gitattributes\` present, and does it conform?
-    - \`.gitattributes\` does not exist in this project.
- ✘  Is \`.gitignore\` present, and does it conform?
-    - \`.gitignore\` does not exist in this project.
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
+- Does the package have a well-formed manifest (\`package.json\`)? ❌
+  - \`package.json\` does not exist in this project.
+- Is \`README.md\` present? ❌
+  - \`README.md\` does not exist in this project.
+- Are all of the files for Yarn Modern present, and do they conform? ❌
+  - \`.yarnrc.yml\` does not exist in this project.
+  - \`.yarn/releases/\` does not exist in this project.
+  - \`.yarn/plugins/\` does not exist in this project.
+- Does the \`src/\` directory exist? ❌
+  - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and does it conform? ❌
+  - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
+- Is \`tsconfig.json\` present, and does it conform? ❌
+  - \`tsconfig.json\` does not exist in this project.
+- Is \`tsconfig.build.json\` present, and does it conform? ❌
+  - \`tsconfig.build.json\` does not exist in this project.
+- Is \`tsup.config.ts\` present, and does it conform? ❌
+  - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ✅
+- Is \`CHANGELOG.md\` well-formatted? ⚠️
+  - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-2/package.json'.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
 Results:       2 passed, 13 failed, 1 errored, 16 total
 Elapsed time:  0 ms
@@ -1162,37 +1162,37 @@ Elapsed time:  0 ms
 repo-2
 ------
 
- ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
- ✘  Does the package have a well-formed manifest (\`package.json\`)?
-    - \`package.json\` does not exist in this project.
- ✘  Is \`README.md\` present?
-    - \`README.md\` does not exist in this project.
- ✘  Are all of the files for Yarn Modern present, and do they conform?
-    - \`.yarnrc.yml\` does not exist in this project.
-    - \`.yarn/releases/\` does not exist in this project.
-    - \`.yarn/plugins/\` does not exist in this project.
- ✘  Does the \`src/\` directory exist?
-    - \`src/\` does not exist in this project.
- ✘  Is \`.nvmrc\` present, and does it conform?
-    - \`.nvmrc\` does not exist in this project.
- ✘  Is \`jest.config.js\` present, and does it conform?
-    - \`jest.config.js\` does not exist in this project.
- ✘  Is \`tsconfig.json\` present, and does it conform?
-    - \`tsconfig.json\` does not exist in this project.
- ✘  Is \`tsconfig.build.json\` present, and does it conform?
-    - \`tsconfig.build.json\` does not exist in this project.
- ✘  Is \`tsup.config.ts\` present, and does it conform?
-    - \`tsup.config.ts\` does not exist in this project.
- ✘  Is \`typedoc.json\` present, and does it conform?
-    - \`typedoc.json\` does not exist in this project.
- ✘  Is \`CHANGELOG.md\` present?
-    - \`CHANGELOG.md\` does not exist in this project.
- ✘  Is \`.editorconfig\` present, and does it conform?
-    - \`.editorconfig\` does not exist in this project.
- ✘  Is \`.gitattributes\` present, and does it conform?
-    - \`.gitattributes\` does not exist in this project.
- ✘  Is \`.gitignore\` present, and does it conform?
-    - \`.gitignore\` does not exist in this project.
+- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
+- Does the package have a well-formed manifest (\`package.json\`)? ❌
+  - \`package.json\` does not exist in this project.
+- Is \`README.md\` present? ❌
+  - \`README.md\` does not exist in this project.
+- Are all of the files for Yarn Modern present, and do they conform? ❌
+  - \`.yarnrc.yml\` does not exist in this project.
+  - \`.yarn/releases/\` does not exist in this project.
+  - \`.yarn/plugins/\` does not exist in this project.
+- Does the \`src/\` directory exist? ❌
+  - \`src/\` does not exist in this project.
+- Is \`.nvmrc\` present, and does it conform? ❌
+  - \`.nvmrc\` does not exist in this project.
+- Is \`jest.config.js\` present, and does it conform? ❌
+  - \`jest.config.js\` does not exist in this project.
+- Is \`tsconfig.json\` present, and does it conform? ❌
+  - \`tsconfig.json\` does not exist in this project.
+- Is \`tsconfig.build.json\` present, and does it conform? ❌
+  - \`tsconfig.build.json\` does not exist in this project.
+- Is \`tsup.config.ts\` present, and does it conform? ❌
+  - \`tsup.config.ts\` does not exist in this project.
+- Is \`typedoc.json\` present, and does it conform? ❌
+  - \`typedoc.json\` does not exist in this project.
+- Is \`CHANGELOG.md\` present? ❌
+  - \`CHANGELOG.md\` does not exist in this project.
+- Is \`.editorconfig\` present, and does it conform? ❌
+  - \`.editorconfig\` does not exist in this project.
+- Is \`.gitattributes\` present, and does it conform? ❌
+  - \`.gitattributes\` does not exist in this project.
+- Is \`.gitignore\` present, and does it conform? ❌
+  - \`.gitignore\` does not exist in this project.
 
 Results:       1 passed, 14 failed, 0 errored, 15 total
 Elapsed time:  0 ms

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -43,7 +43,7 @@ describe('main', () => {
   });
 
   describe('given a list of project references', () => {
-    it('produces a fully passing report if all rules executed against the given projects pass', async () => {
+    it('produces a fully passing report, returning true, if all rules executed against the given projects pass', async () => {
       await withinSandbox(async ({ directoryPath: sandboxDirectoryPath }) => {
         const projectNames = ['repo-1', 'repo-2'];
         const { cachedRepositoriesDirectoryPath, repositories } =
@@ -182,7 +182,7 @@ describe('main', () => {
         }
         const outputLogger = new FakeOutputLogger();
 
-        await main({
+        const isSuccessful = await main({
           argv: ['node', 'module-lint', ...projectNames],
           stdout: outputLogger.stdout,
           stderr: outputLogger.stderr,
@@ -198,104 +198,105 @@ describe('main', () => {
 repo-1
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ✅
-- Does the \`packageManager\` field in \`package.json\` conform? ✅
-- Does the \`engines.node\` field in \`package.json\` conform? ✅
-- Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the test-related \`scripts\` in \`package.json\` conform? ✅
-- Do the typescript-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typescript-related \`scripts\` in \`package.json\` conform? ✅
-- Does the \`exports\` field in \`package.json\` conform? ✅
-- Does the \`main\` field in \`package.json\` conform? ✅
-- Does the \`module\` field in \`package.json\` conform? ✅
-- Does the \`types\` field in \`package.json\` conform? ✅
-- Does the \`files\` field in \`package.json\` conform? ✅
-- Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
-- Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
-- Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
-- Do the lavamoat-related \`devDependencies\` in \`package.json\` conform? ✅
-- Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`? ✅
-- Is \`README.md\` present? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does the README conform by recommending node install from nodejs.org? ✅
-- Are all of the files for Yarn Modern present, and do they conform? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does allow scripts conforms to yarn? ✅
-- Is the allow-scripts Yarn plugin installed? ✅
-- Does the \`src/\` directory exist? ✅
-- Is \`.nvmrc\` present, and does it conform? ✅
-- Is \`jest.config.js\` present, and does it conform? ✅
-- Is \`tsconfig.json\` present, and does it conform? ✅
-- Is \`tsconfig.build.json\` present, and does it conform? ✅
-- Is \`tsup.config.ts\` present, and does it conform? ✅
-- Is \`typedoc.json\` present, and does it conform? ✅
-- Is \`CHANGELOG.md\` present? ✅
-- Is \`CHANGELOG.md\` well-formatted? ✅
-- Is \`.editorconfig\` present, and does it conform? ✅
-- Is \`.gitattributes\` present, and does it conform? ✅
-- Is \`.gitignore\` present, and does it conform? ✅
+ ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
+ ✔︎  Does the package have a well-formed manifest (\`package.json\`)?
+ ✔︎  Does the \`packageManager\` field in \`package.json\` conform?
+ ✔︎  Does the \`engines.node\` field in \`package.json\` conform?
+ ✔︎  Do the lint-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the jest-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the test-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Do the typescript-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the typescript-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Does the \`exports\` field in \`package.json\` conform?
+ ✔︎  Does the \`main\` field in \`package.json\` conform?
+ ✔︎  Does the \`module\` field in \`package.json\` conform?
+ ✔︎  Does the \`types\` field in \`package.json\` conform?
+ ✔︎  Does the \`files\` field in \`package.json\` conform?
+ ✔︎  Does LavaMoat allow scripts for \`tsup>esbuild\`?
+ ✔︎  Do the typedoc-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the typedoc-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Do the changelog-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the changelog-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Do the lavamoat-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`?
+ ✔︎  Is \`README.md\` present?
+ ✔︎  Does the README conform by recommending the correct Yarn version to install?
+ ✔︎  Does the README conform by recommending node install from nodejs.org?
+ ✔︎  Are all of the files for Yarn Modern present, and do they conform?
+ ✔︎  Does the README conform by recommending the correct Yarn version to install?
+ ✔︎  Does allow scripts conforms to yarn?
+ ✔︎  Is the allow-scripts Yarn plugin installed?
+ ✔︎  Does the \`src/\` directory exist?
+ ✔︎  Is \`.nvmrc\` present, and does it conform?
+ ✔︎  Is \`jest.config.js\` present, and does it conform?
+ ✔︎  Is \`tsconfig.json\` present, and does it conform?
+ ✔︎  Is \`tsconfig.build.json\` present, and does it conform?
+ ✔︎  Is \`tsup.config.ts\` present, and does it conform?
+ ✔︎  Is \`typedoc.json\` present, and does it conform?
+ ✔︎  Is \`CHANGELOG.md\` present?
+ ✔︎  Is \`CHANGELOG.md\` well-formatted?
+ ✔︎  Is \`.editorconfig\` present, and does it conform?
+ ✔︎  Is \`.gitattributes\` present, and does it conform?
+ ✔︎  Is \`.gitignore\` present, and does it conform?
 
-Results:       40 passed, 0 failed, 40 total
+Results:       40 passed, 0 failed, 0 errored, 40 total
 Elapsed time:  0 ms
 
 
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ✅
-- Does the \`packageManager\` field in \`package.json\` conform? ✅
-- Does the \`engines.node\` field in \`package.json\` conform? ✅
-- Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the test-related \`scripts\` in \`package.json\` conform? ✅
-- Do the typescript-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typescript-related \`scripts\` in \`package.json\` conform? ✅
-- Does the \`exports\` field in \`package.json\` conform? ✅
-- Does the \`main\` field in \`package.json\` conform? ✅
-- Does the \`module\` field in \`package.json\` conform? ✅
-- Does the \`types\` field in \`package.json\` conform? ✅
-- Does the \`files\` field in \`package.json\` conform? ✅
-- Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
-- Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
-- Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
-- Do the lavamoat-related \`devDependencies\` in \`package.json\` conform? ✅
-- Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`? ✅
-- Is \`README.md\` present? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does the README conform by recommending node install from nodejs.org? ✅
-- Are all of the files for Yarn Modern present, and do they conform? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does allow scripts conforms to yarn? ✅
-- Is the allow-scripts Yarn plugin installed? ✅
-- Does the \`src/\` directory exist? ✅
-- Is \`.nvmrc\` present, and does it conform? ✅
-- Is \`jest.config.js\` present, and does it conform? ✅
-- Is \`tsconfig.json\` present, and does it conform? ✅
-- Is \`tsconfig.build.json\` present, and does it conform? ✅
-- Is \`tsup.config.ts\` present, and does it conform? ✅
-- Is \`typedoc.json\` present, and does it conform? ✅
-- Is \`CHANGELOG.md\` present? ✅
-- Is \`CHANGELOG.md\` well-formatted? ✅
-- Is \`.editorconfig\` present, and does it conform? ✅
-- Is \`.gitattributes\` present, and does it conform? ✅
-- Is \`.gitignore\` present, and does it conform? ✅
+ ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
+ ✔︎  Does the package have a well-formed manifest (\`package.json\`)?
+ ✔︎  Does the \`packageManager\` field in \`package.json\` conform?
+ ✔︎  Does the \`engines.node\` field in \`package.json\` conform?
+ ✔︎  Do the lint-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the jest-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the test-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Do the typescript-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the typescript-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Does the \`exports\` field in \`package.json\` conform?
+ ✔︎  Does the \`main\` field in \`package.json\` conform?
+ ✔︎  Does the \`module\` field in \`package.json\` conform?
+ ✔︎  Does the \`types\` field in \`package.json\` conform?
+ ✔︎  Does the \`files\` field in \`package.json\` conform?
+ ✔︎  Does LavaMoat allow scripts for \`tsup>esbuild\`?
+ ✔︎  Do the typedoc-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the typedoc-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Do the changelog-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the changelog-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Do the lavamoat-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`?
+ ✔︎  Is \`README.md\` present?
+ ✔︎  Does the README conform by recommending the correct Yarn version to install?
+ ✔︎  Does the README conform by recommending node install from nodejs.org?
+ ✔︎  Are all of the files for Yarn Modern present, and do they conform?
+ ✔︎  Does the README conform by recommending the correct Yarn version to install?
+ ✔︎  Does allow scripts conforms to yarn?
+ ✔︎  Is the allow-scripts Yarn plugin installed?
+ ✔︎  Does the \`src/\` directory exist?
+ ✔︎  Is \`.nvmrc\` present, and does it conform?
+ ✔︎  Is \`jest.config.js\` present, and does it conform?
+ ✔︎  Is \`tsconfig.json\` present, and does it conform?
+ ✔︎  Is \`tsconfig.build.json\` present, and does it conform?
+ ✔︎  Is \`tsup.config.ts\` present, and does it conform?
+ ✔︎  Is \`typedoc.json\` present, and does it conform?
+ ✔︎  Is \`CHANGELOG.md\` present?
+ ✔︎  Is \`CHANGELOG.md\` well-formatted?
+ ✔︎  Is \`.editorconfig\` present, and does it conform?
+ ✔︎  Is \`.gitattributes\` present, and does it conform?
+ ✔︎  Is \`.gitignore\` present, and does it conform?
 
-Results:       40 passed, 0 failed, 40 total
+Results:       40 passed, 0 failed, 0 errored, 40 total
 Elapsed time:  0 ms
 
 `,
         );
+        expect(isSuccessful).toBe(true);
       });
     });
 
-    it('produces a fully failing report if all rules executed against the given projects fail, listing reasons for failure', async () => {
+    it('produces a fully failing report, listing reasons for failure and returning false, if all rules executed against the given projects fail', async () => {
       await withinSandbox(async ({ directoryPath: sandboxDirectoryPath }) => {
         const projectNames = ['repo-1', 'repo-2'];
         const { cachedRepositoriesDirectoryPath, repositories } =
@@ -316,7 +317,7 @@ Elapsed time:  0 ms
         }
         const outputLogger = new FakeOutputLogger();
 
-        await main({
+        const isSuccessful = await main({
           argv: ['node', 'module-lint', ...projectNames],
           stdout: outputLogger.stdout,
           stderr: outputLogger.stderr,
@@ -332,88 +333,211 @@ Elapsed time:  0 ms
 repo-1
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ❌
-  - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ❌
-  - \`CHANGELOG.md\` does not exist in this project.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+ ✘  Is the classic Yarn config file (\`.yarnrc\`) absent?
+    - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
+ ✘  Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+ ✘  Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+ ✘  Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+ ✘  Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+ ✘  Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+ ✘  Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+ ✘  Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+ ✘  Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+ ✘  Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+ ✘  Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+ ✘  Is \`CHANGELOG.md\` present?
+    - \`CHANGELOG.md\` does not exist in this project.
+ ✘  Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+ ✘  Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+ ✘  Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 15 failed, 15 total
+Results:       0 passed, 15 failed, 0 errored, 15 total
 Elapsed time:  0 ms
 
 
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ❌
-  - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ❌
-  - \`CHANGELOG.md\` does not exist in this project.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+ ✘  Is the classic Yarn config file (\`.yarnrc\`) absent?
+    - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
+ ✘  Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+ ✘  Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+ ✘  Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+ ✘  Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+ ✘  Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+ ✘  Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+ ✘  Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+ ✘  Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+ ✘  Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+ ✘  Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+ ✘  Is \`CHANGELOG.md\` present?
+    - \`CHANGELOG.md\` does not exist in this project.
+ ✘  Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+ ✘  Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+ ✘  Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 15 failed, 15 total
+Results:       0 passed, 15 failed, 0 errored, 15 total
 Elapsed time:  0 ms
 
 `,
         );
+        expect(isSuccessful).toBe(false);
       });
     });
 
-    it('does not exit immediately if a project errors during linting, but shows the error and continues', async () => {
+    it('does not abort linting of a project if a lint rule throws, but shows the error and continues to the next line rule, returning false', async () => {
+      await withinSandbox(async ({ directoryPath: sandboxDirectoryPath }) => {
+        const projectNames = ['repo-1', 'repo-2'];
+        const { cachedRepositoriesDirectoryPath, repositories } =
+          await setupToolWithMockRepositories({
+            execaMock,
+            sandboxDirectoryPath,
+            repositories: [
+              { name: 'metamask-module-template', create: true },
+              ...projectNames.map((projectName) => ({
+                name: projectName,
+                create: true,
+              })),
+            ],
+          });
+        // Skip first repo since it's the module template
+        for (const repository of repositories.slice(1)) {
+          await writeFile(
+            path.join(repository.directoryPath, 'CHANGELOG.md'),
+            '',
+          );
+        }
+        const outputLogger = new FakeOutputLogger();
+
+        const isSuccessful = await main({
+          argv: ['node', 'module-lint', ...projectNames],
+          stdout: outputLogger.stdout,
+          stderr: outputLogger.stderr,
+          config: {
+            cachedRepositoriesDirectoryPath,
+            defaultProjectNames: [],
+          },
+        });
+
+        expect(outputLogger.getStderr()).toBe('');
+        expect(outputLogger.getStdout()).toBe(
+          `
+repo-1
+------
+
+ ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
+ ✘  Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+ ✘  Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+ ✘  Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+ ✘  Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+ ✘  Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+ ✘  Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+ ✘  Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+ ✘  Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+ ✘  Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+ ✘  Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+ ✔︎  Is \`CHANGELOG.md\` present?
+ ?  Is \`CHANGELOG.md\` well-formatted?
+    - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-1/package.json'.
+ ✘  Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+ ✘  Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+ ✘  Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
+
+Results:       2 passed, 13 failed, 1 errored, 16 total
+Elapsed time:  0 ms
+
+
+repo-2
+------
+
+ ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
+ ✘  Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+ ✘  Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+ ✘  Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+ ✘  Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+ ✘  Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+ ✘  Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+ ✘  Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+ ✘  Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+ ✘  Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+ ✘  Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+ ✔︎  Is \`CHANGELOG.md\` present?
+ ?  Is \`CHANGELOG.md\` well-formatted?
+    - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-2/package.json'.
+ ✘  Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+ ✘  Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+ ✘  Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
+
+Results:       2 passed, 13 failed, 1 errored, 16 total
+Elapsed time:  0 ms
+
+`,
+        );
+        expect(isSuccessful).toBe(false);
+      });
+    });
+
+    it('does not exit immediately if an unknown error is thrown while linting a project, but shows the error and continues, returning false', async () => {
       await withinSandbox(async ({ directoryPath: sandboxDirectoryPath }) => {
         const projectNames = ['repo-1', 'repo-2'];
         const { cachedRepositoriesDirectoryPath } =
@@ -437,7 +561,7 @@ Elapsed time:  0 ms
           });
         const outputLogger = new FakeOutputLogger();
 
-        await main({
+        const isSuccessful = await main({
           argv: ['node', 'module-lint', ...projectNames],
           stdout: outputLogger.stdout,
           stderr: outputLogger.stderr,
@@ -457,49 +581,50 @@ Cloning repository MetaMask/repo-2, please wait...
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ❌
-  - \`CHANGELOG.md\` does not exist in this project.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+ ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
+ ✘  Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+ ✘  Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+ ✘  Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+ ✘  Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+ ✘  Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+ ✘  Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+ ✘  Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+ ✘  Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+ ✘  Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+ ✘  Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+ ✘  Is \`CHANGELOG.md\` present?
+    - \`CHANGELOG.md\` does not exist in this project.
+ ✘  Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+ ✘  Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+ ✘  Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
-Results:       1 passed, 14 failed, 15 total
+Results:       1 passed, 14 failed, 0 errored, 15 total
 Elapsed time:  0 ms
 
 `.trimStart(),
         );
+        expect(isSuccessful).toBe(false);
       });
     });
   });
 
   describe('given no project references', () => {
-    it('produces a fully passing report if all rules executed against the default projects pass', async () => {
+    it('produces a fully passing report, returning true, if all rules executed against the default projects pass', async () => {
       await withinSandbox(async ({ directoryPath: sandboxDirectoryPath }) => {
         const projectNames = ['repo-1', 'repo-2'];
         const { cachedRepositoriesDirectoryPath, repositories } =
@@ -639,7 +764,7 @@ Elapsed time:  0 ms
         }
         const outputLogger = new FakeOutputLogger();
 
-        await main({
+        const isSuccessful = await main({
           argv: ['node', 'module-lint'],
           stdout: outputLogger.stdout,
           stderr: outputLogger.stderr,
@@ -655,104 +780,105 @@ Elapsed time:  0 ms
 repo-1
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ✅
-- Does the \`packageManager\` field in \`package.json\` conform? ✅
-- Does the \`engines.node\` field in \`package.json\` conform? ✅
-- Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the test-related \`scripts\` in \`package.json\` conform? ✅
-- Do the typescript-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typescript-related \`scripts\` in \`package.json\` conform? ✅
-- Does the \`exports\` field in \`package.json\` conform? ✅
-- Does the \`main\` field in \`package.json\` conform? ✅
-- Does the \`module\` field in \`package.json\` conform? ✅
-- Does the \`types\` field in \`package.json\` conform? ✅
-- Does the \`files\` field in \`package.json\` conform? ✅
-- Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
-- Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
-- Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
-- Do the lavamoat-related \`devDependencies\` in \`package.json\` conform? ✅
-- Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`? ✅
-- Is \`README.md\` present? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does the README conform by recommending node install from nodejs.org? ✅
-- Are all of the files for Yarn Modern present, and do they conform? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does allow scripts conforms to yarn? ✅
-- Is the allow-scripts Yarn plugin installed? ✅
-- Does the \`src/\` directory exist? ✅
-- Is \`.nvmrc\` present, and does it conform? ✅
-- Is \`jest.config.js\` present, and does it conform? ✅
-- Is \`tsconfig.json\` present, and does it conform? ✅
-- Is \`tsconfig.build.json\` present, and does it conform? ✅
-- Is \`tsup.config.ts\` present, and does it conform? ✅
-- Is \`typedoc.json\` present, and does it conform? ✅
-- Is \`CHANGELOG.md\` present? ✅
-- Is \`CHANGELOG.md\` well-formatted? ✅
-- Is \`.editorconfig\` present, and does it conform? ✅
-- Is \`.gitattributes\` present, and does it conform? ✅
-- Is \`.gitignore\` present, and does it conform? ✅
+ ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
+ ✔︎  Does the package have a well-formed manifest (\`package.json\`)?
+ ✔︎  Does the \`packageManager\` field in \`package.json\` conform?
+ ✔︎  Does the \`engines.node\` field in \`package.json\` conform?
+ ✔︎  Do the lint-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the jest-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the test-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Do the typescript-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the typescript-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Does the \`exports\` field in \`package.json\` conform?
+ ✔︎  Does the \`main\` field in \`package.json\` conform?
+ ✔︎  Does the \`module\` field in \`package.json\` conform?
+ ✔︎  Does the \`types\` field in \`package.json\` conform?
+ ✔︎  Does the \`files\` field in \`package.json\` conform?
+ ✔︎  Does LavaMoat allow scripts for \`tsup>esbuild\`?
+ ✔︎  Do the typedoc-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the typedoc-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Do the changelog-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the changelog-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Do the lavamoat-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`?
+ ✔︎  Is \`README.md\` present?
+ ✔︎  Does the README conform by recommending the correct Yarn version to install?
+ ✔︎  Does the README conform by recommending node install from nodejs.org?
+ ✔︎  Are all of the files for Yarn Modern present, and do they conform?
+ ✔︎  Does the README conform by recommending the correct Yarn version to install?
+ ✔︎  Does allow scripts conforms to yarn?
+ ✔︎  Is the allow-scripts Yarn plugin installed?
+ ✔︎  Does the \`src/\` directory exist?
+ ✔︎  Is \`.nvmrc\` present, and does it conform?
+ ✔︎  Is \`jest.config.js\` present, and does it conform?
+ ✔︎  Is \`tsconfig.json\` present, and does it conform?
+ ✔︎  Is \`tsconfig.build.json\` present, and does it conform?
+ ✔︎  Is \`tsup.config.ts\` present, and does it conform?
+ ✔︎  Is \`typedoc.json\` present, and does it conform?
+ ✔︎  Is \`CHANGELOG.md\` present?
+ ✔︎  Is \`CHANGELOG.md\` well-formatted?
+ ✔︎  Is \`.editorconfig\` present, and does it conform?
+ ✔︎  Is \`.gitattributes\` present, and does it conform?
+ ✔︎  Is \`.gitignore\` present, and does it conform?
 
-Results:       40 passed, 0 failed, 40 total
+Results:       40 passed, 0 failed, 0 errored, 40 total
 Elapsed time:  0 ms
 
 
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ✅
-- Does the \`packageManager\` field in \`package.json\` conform? ✅
-- Does the \`engines.node\` field in \`package.json\` conform? ✅
-- Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the test-related \`scripts\` in \`package.json\` conform? ✅
-- Do the typescript-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typescript-related \`scripts\` in \`package.json\` conform? ✅
-- Does the \`exports\` field in \`package.json\` conform? ✅
-- Does the \`main\` field in \`package.json\` conform? ✅
-- Does the \`module\` field in \`package.json\` conform? ✅
-- Does the \`types\` field in \`package.json\` conform? ✅
-- Does the \`files\` field in \`package.json\` conform? ✅
-- Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
-- Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
-- Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
-- Do the lavamoat-related \`devDependencies\` in \`package.json\` conform? ✅
-- Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`? ✅
-- Is \`README.md\` present? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does the README conform by recommending node install from nodejs.org? ✅
-- Are all of the files for Yarn Modern present, and do they conform? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does allow scripts conforms to yarn? ✅
-- Is the allow-scripts Yarn plugin installed? ✅
-- Does the \`src/\` directory exist? ✅
-- Is \`.nvmrc\` present, and does it conform? ✅
-- Is \`jest.config.js\` present, and does it conform? ✅
-- Is \`tsconfig.json\` present, and does it conform? ✅
-- Is \`tsconfig.build.json\` present, and does it conform? ✅
-- Is \`tsup.config.ts\` present, and does it conform? ✅
-- Is \`typedoc.json\` present, and does it conform? ✅
-- Is \`CHANGELOG.md\` present? ✅
-- Is \`CHANGELOG.md\` well-formatted? ✅
-- Is \`.editorconfig\` present, and does it conform? ✅
-- Is \`.gitattributes\` present, and does it conform? ✅
-- Is \`.gitignore\` present, and does it conform? ✅
+ ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
+ ✔︎  Does the package have a well-formed manifest (\`package.json\`)?
+ ✔︎  Does the \`packageManager\` field in \`package.json\` conform?
+ ✔︎  Does the \`engines.node\` field in \`package.json\` conform?
+ ✔︎  Do the lint-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the jest-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the test-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Do the typescript-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the typescript-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Does the \`exports\` field in \`package.json\` conform?
+ ✔︎  Does the \`main\` field in \`package.json\` conform?
+ ✔︎  Does the \`module\` field in \`package.json\` conform?
+ ✔︎  Does the \`types\` field in \`package.json\` conform?
+ ✔︎  Does the \`files\` field in \`package.json\` conform?
+ ✔︎  Does LavaMoat allow scripts for \`tsup>esbuild\`?
+ ✔︎  Do the typedoc-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the typedoc-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Do the changelog-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Do the changelog-related \`scripts\` in \`package.json\` conform?
+ ✔︎  Do the lavamoat-related \`devDependencies\` in \`package.json\` conform?
+ ✔︎  Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`?
+ ✔︎  Is \`README.md\` present?
+ ✔︎  Does the README conform by recommending the correct Yarn version to install?
+ ✔︎  Does the README conform by recommending node install from nodejs.org?
+ ✔︎  Are all of the files for Yarn Modern present, and do they conform?
+ ✔︎  Does the README conform by recommending the correct Yarn version to install?
+ ✔︎  Does allow scripts conforms to yarn?
+ ✔︎  Is the allow-scripts Yarn plugin installed?
+ ✔︎  Does the \`src/\` directory exist?
+ ✔︎  Is \`.nvmrc\` present, and does it conform?
+ ✔︎  Is \`jest.config.js\` present, and does it conform?
+ ✔︎  Is \`tsconfig.json\` present, and does it conform?
+ ✔︎  Is \`tsconfig.build.json\` present, and does it conform?
+ ✔︎  Is \`tsup.config.ts\` present, and does it conform?
+ ✔︎  Is \`typedoc.json\` present, and does it conform?
+ ✔︎  Is \`CHANGELOG.md\` present?
+ ✔︎  Is \`CHANGELOG.md\` well-formatted?
+ ✔︎  Is \`.editorconfig\` present, and does it conform?
+ ✔︎  Is \`.gitattributes\` present, and does it conform?
+ ✔︎  Is \`.gitignore\` present, and does it conform?
 
-Results:       40 passed, 0 failed, 40 total
+Results:       40 passed, 0 failed, 0 errored, 40 total
 Elapsed time:  0 ms
 
 `,
         );
+        expect(isSuccessful).toBe(true);
       });
     });
 
-    it('produces a fully failing report if all rules executed against the default projects fail, listing reasons for failure', async () => {
+    it('produces a fully failing report, listing reasons for failure and returning false, if all rules executed against the default projects fail', async () => {
       await withinSandbox(async ({ directoryPath: sandboxDirectoryPath }) => {
         const projectNames = ['repo-1', 'repo-2'];
         const { cachedRepositoriesDirectoryPath, repositories } =
@@ -773,7 +899,7 @@ Elapsed time:  0 ms
         }
         const outputLogger = new FakeOutputLogger();
 
-        await main({
+        const isSuccessful = await main({
           argv: ['node', 'module-lint'],
           stdout: outputLogger.stdout,
           stderr: outputLogger.stderr,
@@ -789,88 +915,211 @@ Elapsed time:  0 ms
 repo-1
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ❌
-  - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ❌
-  - \`CHANGELOG.md\` does not exist in this project.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+ ✘  Is the classic Yarn config file (\`.yarnrc\`) absent?
+    - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
+ ✘  Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+ ✘  Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+ ✘  Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+ ✘  Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+ ✘  Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+ ✘  Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+ ✘  Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+ ✘  Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+ ✘  Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+ ✘  Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+ ✘  Is \`CHANGELOG.md\` present?
+    - \`CHANGELOG.md\` does not exist in this project.
+ ✘  Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+ ✘  Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+ ✘  Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 15 failed, 15 total
+Results:       0 passed, 15 failed, 0 errored, 15 total
 Elapsed time:  0 ms
 
 
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ❌
-  - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ❌
-  - \`CHANGELOG.md\` does not exist in this project.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+ ✘  Is the classic Yarn config file (\`.yarnrc\`) absent?
+    - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
+ ✘  Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+ ✘  Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+ ✘  Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+ ✘  Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+ ✘  Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+ ✘  Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+ ✘  Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+ ✘  Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+ ✘  Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+ ✘  Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+ ✘  Is \`CHANGELOG.md\` present?
+    - \`CHANGELOG.md\` does not exist in this project.
+ ✘  Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+ ✘  Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+ ✘  Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
-Results:       0 passed, 15 failed, 15 total
+Results:       0 passed, 15 failed, 0 errored, 15 total
 Elapsed time:  0 ms
 
 `,
         );
+        expect(isSuccessful).toBe(false);
       });
     });
 
-    it('does not exit immediately if a project errors during linting, but shows the error and continues', async () => {
+    it('does not abort linting of a project if a lint rule throws, but shows the error and continues to the next line rule, returning false', async () => {
+      await withinSandbox(async ({ directoryPath: sandboxDirectoryPath }) => {
+        const projectNames = ['repo-1', 'repo-2'];
+        const { cachedRepositoriesDirectoryPath, repositories } =
+          await setupToolWithMockRepositories({
+            execaMock,
+            sandboxDirectoryPath,
+            repositories: [
+              { name: 'metamask-module-template', create: true },
+              ...projectNames.map((projectName) => ({
+                name: projectName,
+                create: true,
+              })),
+            ],
+          });
+        // Skip first repo since it's the module template
+        for (const repository of repositories.slice(1)) {
+          await writeFile(
+            path.join(repository.directoryPath, 'CHANGELOG.md'),
+            '',
+          );
+        }
+        const outputLogger = new FakeOutputLogger();
+
+        const isSuccessful = await main({
+          argv: ['node', 'module-lint'],
+          stdout: outputLogger.stdout,
+          stderr: outputLogger.stderr,
+          config: {
+            cachedRepositoriesDirectoryPath,
+            defaultProjectNames: projectNames,
+          },
+        });
+
+        expect(outputLogger.getStderr()).toBe('');
+        expect(outputLogger.getStdout()).toBe(
+          `
+repo-1
+------
+
+ ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
+ ✘  Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+ ✘  Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+ ✘  Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+ ✘  Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+ ✘  Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+ ✘  Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+ ✘  Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+ ✘  Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+ ✘  Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+ ✘  Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+ ✔︎  Is \`CHANGELOG.md\` present?
+ ?  Is \`CHANGELOG.md\` well-formatted?
+    - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-1/package.json'.
+ ✘  Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+ ✘  Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+ ✘  Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
+
+Results:       2 passed, 13 failed, 1 errored, 16 total
+Elapsed time:  0 ms
+
+
+repo-2
+------
+
+ ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
+ ✘  Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+ ✘  Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+ ✘  Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+ ✘  Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+ ✘  Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+ ✘  Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+ ✘  Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+ ✘  Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+ ✘  Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+ ✘  Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+ ✔︎  Is \`CHANGELOG.md\` present?
+ ?  Is \`CHANGELOG.md\` well-formatted?
+    - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-2/package.json'.
+ ✘  Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+ ✘  Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+ ✘  Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
+
+Results:       2 passed, 13 failed, 1 errored, 16 total
+Elapsed time:  0 ms
+
+`,
+        );
+        expect(isSuccessful).toBe(false);
+      });
+    });
+
+    it('does not exit immediately if an unknown error is thrown while linting a project, but shows the error and continues, returning false', async () => {
       await withinSandbox(async ({ directoryPath: sandboxDirectoryPath }) => {
         const projectNames = ['repo-1', 'repo-2'];
         const { cachedRepositoriesDirectoryPath } =
@@ -894,7 +1143,7 @@ Elapsed time:  0 ms
           });
         const outputLogger = new FakeOutputLogger();
 
-        await main({
+        const isSuccessful = await main({
           argv: ['node', 'module-lint'],
           stdout: outputLogger.stdout,
           stderr: outputLogger.stderr,
@@ -913,43 +1162,44 @@ Elapsed time:  0 ms
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ❌
-  - \`CHANGELOG.md\` does not exist in this project.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+ ✔︎  Is the classic Yarn config file (\`.yarnrc\`) absent?
+ ✘  Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+ ✘  Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+ ✘  Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+ ✘  Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+ ✘  Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+ ✘  Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+ ✘  Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+ ✘  Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+ ✘  Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+ ✘  Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+ ✘  Is \`CHANGELOG.md\` present?
+    - \`CHANGELOG.md\` does not exist in this project.
+ ✘  Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+ ✘  Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+ ✘  Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
-Results:       1 passed, 14 failed, 15 total
+Results:       1 passed, 14 failed, 0 errored, 15 total
 Elapsed time:  0 ms
 
 `,
         );
+        expect(isSuccessful).toBe(false);
       });
     });
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -252,5 +252,5 @@ async function lintProjects({
     },
   );
 
-  return allPassed && rejectedProjectLintResultPromiseOutcomes.length === 0;
+  return isAllPassed && rejectedProjectLintResultPromiseOutcomes.length === 0;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,16 +51,13 @@ export async function main({
     cachedRepositoriesDirectoryPath: string;
     defaultProjectNames: string[];
   };
-}) {
+}): Promise<boolean> {
   const outputLogger = new OutputLogger({ stdout, stderr });
   const workingDirectoryPath = process.cwd();
 
   const inputs = await parseInputs({ argv, outputLogger, defaultProjectNames });
   if (!inputs) {
-    // Even if `process` changes, it's okay.
-    // eslint-disable-next-line require-atomic-updates
-    process.exitCode = 1;
-    return;
+    return false;
   }
   const { templateRepositoryName, projectReferences } = inputs;
 
@@ -71,7 +68,7 @@ export async function main({
     outputLogger,
   });
 
-  const isAllPassed = await lintProjects({
+  const allLintingSuccessful = await lintProjects({
     projectReferences,
     template,
     workingDirectoryPath,
@@ -79,10 +76,7 @@ export async function main({
     outputLogger,
   });
 
-  if (!isAllPassed) {
-    // eslint-disable-next-line require-atomic-updates
-    process.exitCode = 1;
-  }
+  return allLintingSuccessful;
 }
 
 /**
@@ -231,23 +225,25 @@ async function lintProjects({
     projectLintResultPromiseOutcomes.filter(isPromiseRejectedResult);
 
   outputLogger.logToStdout('');
-  let isAllPassed = true;
+
+  let allPassed = true;
   fulfilledProjectLintResultPromiseOutcomes
     .sort((a, b) => {
       return a.value.projectName.localeCompare(b.value.projectName);
     })
     .forEach((fulfilledProjectLintResultPromiseOutcome, index) => {
-      const { numberOfFailing } = reportProjectLintResult({
+      const { totalFailed, totalErrored } = reportProjectLintResult({
         projectLintResult: fulfilledProjectLintResultPromiseOutcome.value,
         outputLogger,
       });
       if (index < fulfilledProjectLintResultPromiseOutcomes.length - 1) {
         outputLogger.logToStdout('\n');
       }
-      if (numberOfFailing > 0) {
-        isAllPassed = false;
+      if (totalFailed > 0 || totalErrored > 0) {
+        allPassed = false;
       }
     });
+
   outputLogger.logToStdout('');
 
   rejectedProjectLintResultPromiseOutcomes.forEach(
@@ -256,5 +252,5 @@ async function lintProjects({
     },
   );
 
-  return isAllPassed && rejectedProjectLintResultPromiseOutcomes.length === 0;
+  return allPassed && rejectedProjectLintResultPromiseOutcomes.length === 0;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -226,7 +226,7 @@ async function lintProjects({
 
   outputLogger.logToStdout('');
 
-  let allPassed = true;
+  let isAllPassed = true;
   fulfilledProjectLintResultPromiseOutcomes
     .sort((a, b) => {
       return a.value.projectName.localeCompare(b.value.projectName);
@@ -240,7 +240,7 @@ async function lintProjects({
         outputLogger.logToStdout('\n');
       }
       if (totalFailed > 0 || totalErrored > 0) {
-        allPassed = false;
+        isAllPassed = false;
       }
     });
 

--- a/src/report-project-lint-result.test.ts
+++ b/src/report-project-lint-result.test.ts
@@ -1,10 +1,10 @@
-import type { ProjectLintResult } from './lint-project';
+import { RuleExecutionStatus } from './execute-rules';
 import { reportProjectLintResult } from './report-project-lint-result';
 import { FakeOutputLogger } from '../tests/fake-output-logger';
 
 describe('reportProjectLintResult', () => {
-  it('outputs the rules executed against a project and whether they passed or failed, along with a summary', () => {
-    const projectLintResult: ProjectLintResult = {
+  it('outputs the rules executed against a project and whether they passed, failed, or errored, along with a summary', () => {
+    const projectLintResult = {
       projectName: 'some-project',
       elapsedTimeIncludingLinting: 30,
       elapsedTimeExcludingLinting: 0,
@@ -14,7 +14,7 @@ describe('reportProjectLintResult', () => {
             result: {
               ruleName: 'rule-1',
               ruleDescription: 'Description for rule 1',
-              passed: true,
+              status: RuleExecutionStatus.Passed as const,
             },
             elapsedTimeExcludingChildren: 0,
             elapsedTimeIncludingChildren: 0,
@@ -23,7 +23,7 @@ describe('reportProjectLintResult', () => {
                 result: {
                   ruleName: 'rule-2',
                   ruleDescription: 'Description for rule 2',
-                  passed: false,
+                  status: RuleExecutionStatus.Failed as const,
                   failures: [
                     { message: 'Failure 1' },
                     { message: 'Failure 2' },
@@ -39,7 +39,18 @@ describe('reportProjectLintResult', () => {
             result: {
               ruleName: 'rule-3',
               ruleDescription: 'Description for rule 3',
-              passed: true,
+              status: RuleExecutionStatus.Passed as const,
+            },
+            elapsedTimeExcludingChildren: 0,
+            elapsedTimeIncludingChildren: 0,
+            children: [],
+          },
+          {
+            result: {
+              ruleName: 'rule-4',
+              ruleDescription: 'Description for rule 4',
+              status: RuleExecutionStatus.Errored as const,
+              error: new Error('oops'),
             },
             elapsedTimeExcludingChildren: 0,
             elapsedTimeIncludingChildren: 0,
@@ -60,37 +71,27 @@ describe('reportProjectLintResult', () => {
 some-project
 ------------
 
-- Description for rule 1 ✅
-- Description for rule 2 ❌
-  - Failure 1
-  - Failure 2
-- Description for rule 3 ✅
+ ✔︎  Description for rule 1
+ ✘  Description for rule 2
+    - Failure 1
+    - Failure 2
+ ✔︎  Description for rule 3
+ ?  Description for rule 4
+    - ERROR: oops
 
-Results:       2 passed, 1 failed, 3 total
+Results:       2 passed, 1 failed, 1 errored, 4 total
 Elapsed time:  30 ms
 `.trimStart(),
     );
   });
 
-  it('prints "0 passed" if no rules passed', () => {
-    const projectLintResult: ProjectLintResult = {
+  it('outputs an empty report if no rules were executed', () => {
+    const projectLintResult = {
       projectName: 'some-project',
       elapsedTimeIncludingLinting: 30,
       elapsedTimeExcludingLinting: 0,
       ruleExecutionResultTree: {
-        children: [
-          {
-            result: {
-              ruleName: 'some-rule',
-              ruleDescription: 'Description for rule',
-              passed: false,
-              failures: [{ message: 'Some failure' }],
-            },
-            elapsedTimeExcludingChildren: 0,
-            elapsedTimeIncludingChildren: 0,
-            children: [],
-          },
-        ],
+        children: [],
       },
     };
     const outputLogger = new FakeOutputLogger();
@@ -105,50 +106,7 @@ Elapsed time:  30 ms
 some-project
 ------------
 
-- Description for rule ❌
-  - Some failure
-
-Results:       0 passed, 1 failed, 1 total
-Elapsed time:  30 ms
-`.trimStart(),
-    );
-  });
-
-  it('prints "0 failed" if no rules failed', () => {
-    const projectLintResult: ProjectLintResult = {
-      projectName: 'some-project',
-      elapsedTimeIncludingLinting: 30,
-      elapsedTimeExcludingLinting: 0,
-      ruleExecutionResultTree: {
-        children: [
-          {
-            result: {
-              ruleName: 'some-rule',
-              ruleDescription: 'Description for rule',
-              passed: true,
-            },
-            elapsedTimeExcludingChildren: 0,
-            elapsedTimeIncludingChildren: 0,
-            children: [],
-          },
-        ],
-      },
-    };
-    const outputLogger = new FakeOutputLogger();
-
-    reportProjectLintResult({
-      projectLintResult,
-      outputLogger,
-    });
-
-    expect(outputLogger.getStdout()).toBe(
-      `
-some-project
-------------
-
-- Description for rule ✅
-
-Results:       1 passed, 0 failed, 1 total
+Results:       0 passed, 0 failed, 0 errored, 0 total
 Elapsed time:  30 ms
 `.trimStart(),
     );

--- a/src/report-project-lint-result.test.ts
+++ b/src/report-project-lint-result.test.ts
@@ -71,13 +71,13 @@ describe('reportProjectLintResult', () => {
 some-project
 ------------
 
- ✔︎  Description for rule 1
- ✘  Description for rule 2
-    - Failure 1
-    - Failure 2
- ✔︎  Description for rule 3
- ?  Description for rule 4
-    - ERROR: oops
+- Description for rule 1 ✅
+- Description for rule 2 ❌
+  - Failure 1
+  - Failure 2
+- Description for rule 3 ✅
+- Description for rule 4 ⚠️
+  - ERROR: oops
 
 Results:       2 passed, 1 failed, 1 errored, 4 total
 Elapsed time:  30 ms

--- a/src/report-project-lint-result.ts
+++ b/src/report-project-lint-result.ts
@@ -89,12 +89,12 @@ export function reportProjectLintResult({
  */
 function determineIconFor(ruleExecutionStatus: RuleExecutionStatus) {
   if (ruleExecutionStatus === RuleExecutionStatus.Failed) {
-    return chalk.white.bgRed(' ✘ ');
+    return '❌';
   }
   if (ruleExecutionStatus === RuleExecutionStatus.Errored) {
-    return chalk.black.bgYellow(' ? ');
+    return '⚠️';
   }
-  return chalk.black.bgGreen(' ✔︎ ');
+  return '✅';
 }
 
 /**
@@ -119,9 +119,9 @@ function reportRuleExecutionResultNodes({
 
   for (const ruleExecutionResultNode of ruleExecutionResultNodes) {
     outputLogger.logToStdout(
-      `${determineIconFor(ruleExecutionResultNode.result.status)} ${
-        ruleExecutionResultNode.result.ruleDescription
-      }`,
+      `- ${ruleExecutionResultNode.result.ruleDescription} ${determineIconFor(
+        ruleExecutionResultNode.result.status,
+      )}`,
     );
 
     if (ruleExecutionResultNode.result.status === RuleExecutionStatus.Passed) {
@@ -132,7 +132,7 @@ function reportRuleExecutionResultNodes({
       totalFailed += 1;
 
       for (const failure of ruleExecutionResultNode.result.failures) {
-        outputLogger.logToStdout(indent(`- ${chalk.red(failure.message)}`, 2));
+        outputLogger.logToStdout(indent(`- ${chalk.red(failure.message)}`, 1));
       }
     } else if (
       ruleExecutionResultNode.result.status === RuleExecutionStatus.Errored
@@ -144,7 +144,7 @@ function reportRuleExecutionResultNodes({
           `- ${chalk.yellow(
             `ERROR: ${getErrorMessage(ruleExecutionResultNode.result.error)}`,
           )}`,
-          2,
+          1,
         ),
       );
     }

--- a/src/rules/all-yarn-modern-files-conform.test.ts
+++ b/src/rules/all-yarn-modern-files-conform.test.ts
@@ -49,7 +49,7 @@ describe('Rule: all-yarn-modern-files-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -93,7 +93,7 @@ describe('Rule: all-yarn-modern-files-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`.yarnrc.yml` does not exist in this project.',
@@ -142,7 +142,7 @@ describe('Rule: all-yarn-modern-files-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`.yarn/releases/` does not exist in this project.',
@@ -195,7 +195,7 @@ describe('Rule: all-yarn-modern-files-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -245,7 +245,7 @@ describe('Rule: all-yarn-modern-files-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`.yarn/plugins/` does not exist in this project.',
@@ -298,7 +298,7 @@ describe('Rule: all-yarn-modern-files-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/classic-yarn-config-file-absent.test.ts
+++ b/src/rules/classic-yarn-config-file-absent.test.ts
@@ -21,7 +21,7 @@ describe('Rule: classic-yarn-config-file-absent', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -45,7 +45,7 @@ describe('Rule: classic-yarn-config-file-absent', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-allow-scripts-yarn-conform.test.ts
+++ b/src/rules/package-allow-scripts-yarn-conform.test.ts
@@ -30,7 +30,7 @@ describe('Rule: package-allow-scripts-yarn-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -58,7 +58,7 @@ describe('Rule: package-allow-scripts-yarn-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-allow-scripts-yarn-plugins-conform.test.ts
+++ b/src/rules/package-allow-scripts-yarn-plugins-conform.test.ts
@@ -52,7 +52,7 @@ describe('Rule: package-allow-scripts-yarn-plugins-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -97,7 +97,7 @@ describe('Rule: package-allow-scripts-yarn-plugins-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -152,7 +152,7 @@ describe('Rule: package-allow-scripts-yarn-plugins-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-changelog-dev-dependencies-conform.test.ts
+++ b/src/rules/package-changelog-dev-dependencies-conform.test.ts
@@ -43,7 +43,7 @@ describe('Rule: package-changelog-dev-dependencies-conform', () => {
         fail,
       });
 
-      expect(result).toStrictEqual({ passed: true });
+      expect(result).toStrictEqual({ status: 'passed' });
     });
   });
 
@@ -81,7 +81,7 @@ describe('Rule: package-changelog-dev-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -126,7 +126,7 @@ describe('Rule: package-changelog-dev-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-changelog-scripts-conform.test.ts
+++ b/src/rules/package-changelog-scripts-conform.test.ts
@@ -45,7 +45,7 @@ describe('Rule: package-changelog-scripts-conform', () => {
         fail,
       });
 
-      expect(result).toStrictEqual({ passed: true });
+      expect(result).toStrictEqual({ status: 'passed' });
     });
   });
 
@@ -85,7 +85,7 @@ describe('Rule: package-changelog-scripts-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -131,7 +131,7 @@ describe('Rule: package-changelog-scripts-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -216,7 +216,7 @@ describe('Rule: package-changelog-scripts-conform', () => {
         fail,
       });
 
-      expect(result).toStrictEqual({ passed: true });
+      expect(result).toStrictEqual({ status: 'passed' });
     });
   });
 
@@ -256,7 +256,7 @@ describe('Rule: package-changelog-scripts-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-engines-node-field-conforms.test.ts
+++ b/src/rules/package-engines-node-field-conforms.test.ts
@@ -37,7 +37,7 @@ describe('Rule: package-engines-node-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -69,7 +69,7 @@ describe('Rule: package-engines-node-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-exports-field-conforms.test.ts
+++ b/src/rules/package-exports-field-conforms.test.ts
@@ -52,7 +52,7 @@ describe('Rule: package-exports-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -98,7 +98,7 @@ describe('Rule: package-exports-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-files-field-conforms.test.ts
+++ b/src/rules/package-files-field-conforms.test.ts
@@ -37,7 +37,7 @@ describe('Rule: package-files-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -69,7 +69,7 @@ describe('Rule: package-files-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-jest-dependencies-conform.test.ts
+++ b/src/rules/package-jest-dependencies-conform.test.ts
@@ -41,7 +41,7 @@ describe('Rule: package-jest-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -77,7 +77,7 @@ describe('Rule: package-jest-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           { message: '`jest` is "0.0.1", when it should be "1.0.0".' },
         ],
@@ -116,7 +116,7 @@ describe('Rule: package-jest-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-lavamoat-allow-scripts-conforms.test.ts
+++ b/src/rules/package-lavamoat-allow-scripts-conforms.test.ts
@@ -37,7 +37,7 @@ describe('Rule: package-lavamoat-allow-scripts-conforms', () => {
         fail,
       });
 
-      expect(result).toStrictEqual({ passed: true });
+      expect(result).toStrictEqual({ status: 'passed' });
     });
   });
 
@@ -69,7 +69,7 @@ describe('Rule: package-lavamoat-allow-scripts-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-lavamoat-dev-dependencies-conform.test.ts
+++ b/src/rules/package-lavamoat-dev-dependencies-conform.test.ts
@@ -45,7 +45,7 @@ describe('Rule: package-lavamoat-dev-dependencies-conform', () => {
         fail,
       });
 
-      expect(result).toStrictEqual({ passed: true });
+      expect(result).toStrictEqual({ status: 'passed' });
     });
   });
 
@@ -85,7 +85,7 @@ describe('Rule: package-lavamoat-dev-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -131,7 +131,7 @@ describe('Rule: package-lavamoat-dev-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-lavamoat-tsup-conforms.test.ts
+++ b/src/rules/package-lavamoat-tsup-conforms.test.ts
@@ -48,7 +48,7 @@ describe('Rule: package-lavamoat-tsup-conforms', () => {
         fail,
       });
 
-      expect(result).toStrictEqual({ passed: true });
+      expect(result).toStrictEqual({ status: 'passed' });
     });
   });
 
@@ -91,7 +91,7 @@ describe('Rule: package-lavamoat-tsup-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`tsup>esbuild` is false, when it should be true.',
@@ -139,7 +139,7 @@ describe('Rule: package-lavamoat-tsup-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -180,7 +180,7 @@ describe('Rule: package-lavamoat-tsup-conforms', () => {
         pass,
         fail,
       });
-      expect(result).toStrictEqual({ passed: true });
+      expect(result).toStrictEqual({ status: 'passed' });
     });
   });
 });

--- a/src/rules/package-lint-dependencies-conform.test.ts
+++ b/src/rules/package-lint-dependencies-conform.test.ts
@@ -59,7 +59,7 @@ describe('Rule: package-lint-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -113,7 +113,7 @@ describe('Rule: package-lint-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           { message: '`eslint` is "0.0.1", when it should be "1.0.0".' },
         ],
@@ -169,7 +169,7 @@ describe('Rule: package-lint-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -218,7 +218,7 @@ describe('Rule: package-lint-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });

--- a/src/rules/package-main-field-conforms.test.ts
+++ b/src/rules/package-main-field-conforms.test.ts
@@ -41,7 +41,7 @@ describe('Rule: package-main-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -77,7 +77,7 @@ describe('Rule: package-main-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: "`main` is 'test', when it should be 'test-main'.",

--- a/src/rules/package-module-field-conforms.test.ts
+++ b/src/rules/package-module-field-conforms.test.ts
@@ -41,7 +41,7 @@ describe('Rule: package-module-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -77,7 +77,7 @@ describe('Rule: package-module-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: "`module` is 'test', when it should be 'test-module'.",

--- a/src/rules/package-package-manager-field-conforms.test.ts
+++ b/src/rules/package-package-manager-field-conforms.test.ts
@@ -41,7 +41,7 @@ describe('Rule: package-manager-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -77,7 +77,7 @@ describe('Rule: package-manager-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           { message: '`packageManager` is "test", when it should be "yarn".' },
         ],

--- a/src/rules/package-test-scripts-conform.test.ts
+++ b/src/rules/package-test-scripts-conform.test.ts
@@ -41,7 +41,7 @@ describe('Rule: package-test-scripts-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -77,7 +77,7 @@ describe('Rule: package-test-scripts-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -119,7 +119,7 @@ describe('Rule: package-test-scripts-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-typedoc-dev-dependencies-conform.test.ts
+++ b/src/rules/package-typedoc-dev-dependencies-conform.test.ts
@@ -43,7 +43,7 @@ describe('Rule: package-typedoc-dev-dependencies-conform', () => {
         fail,
       });
 
-      expect(result).toStrictEqual({ passed: true });
+      expect(result).toStrictEqual({ status: 'passed' });
     });
   });
 
@@ -81,7 +81,7 @@ describe('Rule: package-typedoc-dev-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -126,7 +126,7 @@ describe('Rule: package-typedoc-dev-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-typedoc-scripts-conform.test.ts
+++ b/src/rules/package-typedoc-scripts-conform.test.ts
@@ -39,7 +39,7 @@ describe('Rule: package-typedoc-scripts-conform', () => {
         fail,
       });
 
-      expect(result).toStrictEqual({ passed: true });
+      expect(result).toStrictEqual({ status: 'passed' });
     });
   });
 
@@ -73,7 +73,7 @@ describe('Rule: package-typedoc-scripts-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -114,7 +114,7 @@ describe('Rule: package-typedoc-scripts-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-types-field-conforms.test.ts
+++ b/src/rules/package-types-field-conforms.test.ts
@@ -37,7 +37,7 @@ describe('Rule: package-types-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -69,7 +69,7 @@ describe('Rule: package-types-field-conforms', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: "`types` is 'test', when it should be 'test-types'.",

--- a/src/rules/package-typescript-dev-dependencies-conform.test.ts
+++ b/src/rules/package-typescript-dev-dependencies-conform.test.ts
@@ -49,7 +49,7 @@ describe('Rule: package-typescript-dev-dependencies-conform', () => {
         fail,
       });
 
-      expect(result).toStrictEqual({ passed: true });
+      expect(result).toStrictEqual({ status: 'passed' });
     });
   });
 
@@ -93,7 +93,7 @@ describe('Rule: package-typescript-dev-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -143,7 +143,7 @@ describe('Rule: package-typescript-dev-dependencies-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/package-typescript-scripts-conform.test.ts
+++ b/src/rules/package-typescript-scripts-conform.test.ts
@@ -45,7 +45,7 @@ describe('Rule: package-typescript-scripts-conform', () => {
         fail,
       });
 
-      expect(result).toStrictEqual({ passed: true });
+      expect(result).toStrictEqual({ status: 'passed' });
     });
   });
 
@@ -85,7 +85,7 @@ describe('Rule: package-typescript-scripts-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:
@@ -131,7 +131,7 @@ describe('Rule: package-typescript-scripts-conform', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/readme-lists-correct-yarn-version.test.ts
+++ b/src/rules/readme-lists-correct-yarn-version.test.ts
@@ -33,7 +33,7 @@ describe('Rule: readme-lists-correct-yarn-version', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -65,7 +65,7 @@ describe('Rule: readme-lists-correct-yarn-version', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/readme-recommends-node-install.test.ts
+++ b/src/rules/readme-recommends-node-install.test.ts
@@ -33,7 +33,7 @@ describe('Rule: readme-recommends-node-install', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -65,7 +65,7 @@ describe('Rule: readme-recommends-node-install', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/require-changelog.test.ts
+++ b/src/rules/require-changelog.test.ts
@@ -25,7 +25,7 @@ describe('Rule: require-changelog', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -45,7 +45,7 @@ describe('Rule: require-changelog', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`CHANGELOG.md` does not exist in this project.',

--- a/src/rules/require-editorconfig.test.ts
+++ b/src/rules/require-editorconfig.test.ts
@@ -33,7 +33,7 @@ describe('Rule: require-editorconfig', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -61,7 +61,7 @@ describe('Rule: require-editorconfig', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`.editorconfig` does not exist in this project.',

--- a/src/rules/require-gitattributes.test.ts
+++ b/src/rules/require-gitattributes.test.ts
@@ -33,7 +33,7 @@ describe('Rule: require-gitattributes', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -61,7 +61,7 @@ describe('Rule: require-gitattributes', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`.gitattributes` does not exist in this project.',

--- a/src/rules/require-gitignore.test.ts
+++ b/src/rules/require-gitignore.test.ts
@@ -33,7 +33,7 @@ describe('Rule: require-gitignore', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -61,7 +61,7 @@ describe('Rule: require-gitignore', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`.gitignore` does not exist in this project.',

--- a/src/rules/require-nvmrc.test.ts
+++ b/src/rules/require-nvmrc.test.ts
@@ -33,7 +33,7 @@ describe('Rule: require-nvmrc', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -61,7 +61,7 @@ describe('Rule: require-nvmrc', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`.nvmrc` does not exist in this project.',

--- a/src/rules/require-readme.test.ts
+++ b/src/rules/require-readme.test.ts
@@ -25,7 +25,7 @@ describe('Rule: require-readme', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -45,7 +45,7 @@ describe('Rule: require-readme', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`README.md` does not exist in this project.',

--- a/src/rules/require-source-directory.test.ts
+++ b/src/rules/require-source-directory.test.ts
@@ -27,7 +27,7 @@ describe('Rule: require-source-directory', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -47,7 +47,7 @@ describe('Rule: require-source-directory', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`src/` does not exist in this project.',
@@ -73,7 +73,7 @@ describe('Rule: require-source-directory', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`src/` is not a directory when it should be.',

--- a/src/rules/require-tsconfig-build.test.ts
+++ b/src/rules/require-tsconfig-build.test.ts
@@ -33,7 +33,7 @@ describe('Rule: require-tsconfig-build', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -61,7 +61,7 @@ describe('Rule: require-tsconfig-build', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`tsconfig.build.json` does not exist in this project.',

--- a/src/rules/require-tsconfig.test.ts
+++ b/src/rules/require-tsconfig.test.ts
@@ -33,7 +33,7 @@ describe('Rule: require-tsconfig', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -61,7 +61,7 @@ describe('Rule: require-tsconfig', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`tsconfig.json` does not exist in this project.',

--- a/src/rules/require-tsup-config.test.ts
+++ b/src/rules/require-tsup-config.test.ts
@@ -33,7 +33,7 @@ describe('Rule: require-tsup-config', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -61,7 +61,7 @@ describe('Rule: require-tsup-config', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`tsup.config.ts` does not exist in this project.',

--- a/src/rules/require-typedoc.test.ts
+++ b/src/rules/require-typedoc.test.ts
@@ -33,7 +33,7 @@ describe('Rule: require-typedoc', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -61,7 +61,7 @@ describe('Rule: require-typedoc', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`typedoc.json` does not exist in this project.',

--- a/src/rules/require-valid-changelog.test.ts
+++ b/src/rules/require-valid-changelog.test.ts
@@ -61,7 +61,7 @@ describe('Rule: require-valid-changelog', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -96,7 +96,7 @@ describe('Rule: require-valid-changelog', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: 'Changelog is not well-formatted.',

--- a/src/rules/require-valid-package-manifest.test.ts
+++ b/src/rules/require-valid-package-manifest.test.ts
@@ -29,7 +29,7 @@ describe('Rule: require-package-manifest', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: true,
+        status: 'passed',
       });
     });
   });
@@ -49,7 +49,7 @@ describe('Rule: require-package-manifest', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message: '`package.json` does not exist in this project.',
@@ -78,7 +78,7 @@ describe('Rule: require-package-manifest', () => {
       });
 
       expect(result).toStrictEqual({
-        passed: false,
+        status: 'failed',
         failures: [
           {
             message:

--- a/src/rules/require-valid-package-manifest.ts
+++ b/src/rules/require-valid-package-manifest.ts
@@ -2,6 +2,7 @@ import { isErrorWithCode, isErrorWithMessage } from '@metamask/utils/node';
 
 import { buildRule } from './build-rule';
 import { PackageManifestSchema, RuleName } from './types';
+import { RuleExecutionStatus } from '../execute-rules';
 import { fileExists } from '../rule-helpers';
 
 export default buildRule({
@@ -16,7 +17,7 @@ export default buildRule({
       entryPath,
       ruleExecutionArguments,
     );
-    if (!fileExistsResult.passed) {
+    if (fileExistsResult.status !== RuleExecutionStatus.Passed) {
       return fileExistsResult;
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

If a project is being linted and a rule throws an error — perhaps it relies on a file to be in a certain format, or some other reason — then linting for that project will halt, and the lint report for that project will only show that error. An error like this signifies a bug in `module-lint`, but sometimes we can't fix that bug right away, and in the meantime this makes the report useless, since we don't know whether any of the other rules passed or not.

This commit fixes this problem by catching errors inside of rules and displaying them as such. To implement this change, we needed to convert the binary status of a rule to a trinary status ("passed", "failed", "errored"). We also updated the output of the lint report to display this error status and distinguish it from a failed status.

## References

See [this recent `module-lint` run](https://github.com/MetaMask/module-lint-fork/actions/runs/9334716033/job/25693269751) for an example of why the output is useless when an error is thrown instead of caught.

Fixes #86.

## Screenshots

### Before

In this example we run `yarn run-tool utils`. Note how no rules are listed at all but rather a single error is shown:

<img width="1728" alt="Screenshot 2024-06-03 at 4 03 12 PM" src="https://github.com/MetaMask/module-lint/assets/7371/a73a5005-bfcf-4af8-9d61-6cf879120f72">

In this example we run `yarn run-tool .` (which lints `module-lint` itself):

<img width="871" alt="Screenshot 2024-06-03 at 3 45 46 PM" src="https://github.com/MetaMask/module-lint/assets/7371/b1b816cb-4435-4a3b-9dd1-af63a3ed20c4">

<img width="833" alt="Screenshot 2024-06-03 at 3 45 57 PM" src="https://github.com/MetaMask/module-lint/assets/7371/c0047fd1-edf2-4e9c-8b8c-0055ab5a82ac">

### After

Running `yarn run-tool utils`. Note how instead of a single error being shown, the statuses of rules are shown and the error that's thrown in one of the rules is displayed:

<img width="1728" alt="Screenshot 2024-06-05 at 1 53 38 PM" src="https://github.com/MetaMask/module-lint/assets/7371/fda40028-a529-4a33-bc25-29b7dfb323a2">

Running `yarn run-tool .`:

<img width="848" alt="Screenshot 2024-06-05 at 1 54 20 PM" src="https://github.com/MetaMask/module-lint/assets/7371/266fffb5-2426-4029-8a1b-fa1519923863">

<img width="708" alt="Screenshot 2024-06-05 at 1 54 28 PM" src="https://github.com/MetaMask/module-lint/assets/7371/e8f15076-8a1e-4976-937d-bba39a73a1ff">
