### PR TITLE
Update report output format

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -198,46 +198,46 @@ describe('main', () => {
 repo-1
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ✅
-- Does the \`packageManager\` field in \`package.json\` conform? ✅
-- Does the \`engines.node\` field in \`package.json\` conform? ✅
-- Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the test-related \`scripts\` in \`package.json\` conform? ✅
-- Do the typescript-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typescript-related \`scripts\` in \`package.json\` conform? ✅
-- Does the \`exports\` field in \`package.json\` conform? ✅
-- Does the \`main\` field in \`package.json\` conform? ✅
-- Does the \`module\` field in \`package.json\` conform? ✅
-- Does the \`types\` field in \`package.json\` conform? ✅
-- Does the \`files\` field in \`package.json\` conform? ✅
-- Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
-- Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
-- Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
-- Do the lavamoat-related \`devDependencies\` in \`package.json\` conform? ✅
-- Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`? ✅
-- Is \`README.md\` present? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does the README conform by recommending node install from nodejs.org? ✅
-- Are all of the files for Yarn Modern present, and do they conform? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does allow scripts conforms to yarn? ✅
-- Is the allow-scripts Yarn plugin installed? ✅
-- Does the \`src/\` directory exist? ✅
-- Is \`.nvmrc\` present, and does it conform? ✅
-- Is \`jest.config.js\` present, and does it conform? ✅
-- Is \`tsconfig.json\` present, and does it conform? ✅
-- Is \`tsconfig.build.json\` present, and does it conform? ✅
-- Is \`tsup.config.ts\` present, and does it conform? ✅
-- Is \`typedoc.json\` present, and does it conform? ✅
-- Is \`CHANGELOG.md\` present? ✅
-- Is \`CHANGELOG.md\` well-formatted? ✅
-- Is \`.editorconfig\` present, and does it conform? ✅
-- Is \`.gitattributes\` present, and does it conform? ✅
-- Is \`.gitignore\` present, and does it conform? ✅
+[✔︎] Is the classic Yarn config file (\`.yarnrc\`) absent?
+[✔︎] Does the package have a well-formed manifest (\`package.json\`)?
+[✔︎] Does the \`packageManager\` field in \`package.json\` conform?
+[✔︎] Does the \`engines.node\` field in \`package.json\` conform?
+[✔︎] Do the lint-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the jest-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the test-related \`scripts\` in \`package.json\` conform?
+[✔︎] Do the typescript-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the typescript-related \`scripts\` in \`package.json\` conform?
+[✔︎] Does the \`exports\` field in \`package.json\` conform?
+[✔︎] Does the \`main\` field in \`package.json\` conform?
+[✔︎] Does the \`module\` field in \`package.json\` conform?
+[✔︎] Does the \`types\` field in \`package.json\` conform?
+[✔︎] Does the \`files\` field in \`package.json\` conform?
+[✔︎] Does LavaMoat allow scripts for \`tsup>esbuild\`?
+[✔︎] Do the typedoc-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the typedoc-related \`scripts\` in \`package.json\` conform?
+[✔︎] Do the changelog-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the changelog-related \`scripts\` in \`package.json\` conform?
+[✔︎] Do the lavamoat-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`?
+[✔︎] Is \`README.md\` present?
+[✔︎] Does the README conform by recommending the correct Yarn version to install?
+[✔︎] Does the README conform by recommending node install from nodejs.org?
+[✔︎] Are all of the files for Yarn Modern present, and do they conform?
+[✔︎] Does the README conform by recommending the correct Yarn version to install?
+[✔︎] Does allow scripts conforms to yarn?
+[✔︎] Is the allow-scripts Yarn plugin installed?
+[✔︎] Does the \`src/\` directory exist?
+[✔︎] Is \`.nvmrc\` present, and does it conform?
+[✔︎] Is \`jest.config.js\` present, and does it conform?
+[✔︎] Is \`tsconfig.json\` present, and does it conform?
+[✔︎] Is \`tsconfig.build.json\` present, and does it conform?
+[✔︎] Is \`tsup.config.ts\` present, and does it conform?
+[✔︎] Is \`typedoc.json\` present, and does it conform?
+[✔︎] Is \`CHANGELOG.md\` present?
+[✔︎] Is \`CHANGELOG.md\` well-formatted?
+[✔︎] Is \`.editorconfig\` present, and does it conform?
+[✔︎] Is \`.gitattributes\` present, and does it conform?
+[✔︎] Is \`.gitignore\` present, and does it conform?
 
 Results:       40 passed, 0 failed, 0 errored, 40 total
 Elapsed time:  0 ms
@@ -246,46 +246,46 @@ Elapsed time:  0 ms
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ✅
-- Does the \`packageManager\` field in \`package.json\` conform? ✅
-- Does the \`engines.node\` field in \`package.json\` conform? ✅
-- Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the test-related \`scripts\` in \`package.json\` conform? ✅
-- Do the typescript-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typescript-related \`scripts\` in \`package.json\` conform? ✅
-- Does the \`exports\` field in \`package.json\` conform? ✅
-- Does the \`main\` field in \`package.json\` conform? ✅
-- Does the \`module\` field in \`package.json\` conform? ✅
-- Does the \`types\` field in \`package.json\` conform? ✅
-- Does the \`files\` field in \`package.json\` conform? ✅
-- Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
-- Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
-- Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
-- Do the lavamoat-related \`devDependencies\` in \`package.json\` conform? ✅
-- Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`? ✅
-- Is \`README.md\` present? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does the README conform by recommending node install from nodejs.org? ✅
-- Are all of the files for Yarn Modern present, and do they conform? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does allow scripts conforms to yarn? ✅
-- Is the allow-scripts Yarn plugin installed? ✅
-- Does the \`src/\` directory exist? ✅
-- Is \`.nvmrc\` present, and does it conform? ✅
-- Is \`jest.config.js\` present, and does it conform? ✅
-- Is \`tsconfig.json\` present, and does it conform? ✅
-- Is \`tsconfig.build.json\` present, and does it conform? ✅
-- Is \`tsup.config.ts\` present, and does it conform? ✅
-- Is \`typedoc.json\` present, and does it conform? ✅
-- Is \`CHANGELOG.md\` present? ✅
-- Is \`CHANGELOG.md\` well-formatted? ✅
-- Is \`.editorconfig\` present, and does it conform? ✅
-- Is \`.gitattributes\` present, and does it conform? ✅
-- Is \`.gitignore\` present, and does it conform? ✅
+[✔︎] Is the classic Yarn config file (\`.yarnrc\`) absent?
+[✔︎] Does the package have a well-formed manifest (\`package.json\`)?
+[✔︎] Does the \`packageManager\` field in \`package.json\` conform?
+[✔︎] Does the \`engines.node\` field in \`package.json\` conform?
+[✔︎] Do the lint-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the jest-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the test-related \`scripts\` in \`package.json\` conform?
+[✔︎] Do the typescript-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the typescript-related \`scripts\` in \`package.json\` conform?
+[✔︎] Does the \`exports\` field in \`package.json\` conform?
+[✔︎] Does the \`main\` field in \`package.json\` conform?
+[✔︎] Does the \`module\` field in \`package.json\` conform?
+[✔︎] Does the \`types\` field in \`package.json\` conform?
+[✔︎] Does the \`files\` field in \`package.json\` conform?
+[✔︎] Does LavaMoat allow scripts for \`tsup>esbuild\`?
+[✔︎] Do the typedoc-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the typedoc-related \`scripts\` in \`package.json\` conform?
+[✔︎] Do the changelog-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the changelog-related \`scripts\` in \`package.json\` conform?
+[✔︎] Do the lavamoat-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`?
+[✔︎] Is \`README.md\` present?
+[✔︎] Does the README conform by recommending the correct Yarn version to install?
+[✔︎] Does the README conform by recommending node install from nodejs.org?
+[✔︎] Are all of the files for Yarn Modern present, and do they conform?
+[✔︎] Does the README conform by recommending the correct Yarn version to install?
+[✔︎] Does allow scripts conforms to yarn?
+[✔︎] Is the allow-scripts Yarn plugin installed?
+[✔︎] Does the \`src/\` directory exist?
+[✔︎] Is \`.nvmrc\` present, and does it conform?
+[✔︎] Is \`jest.config.js\` present, and does it conform?
+[✔︎] Is \`tsconfig.json\` present, and does it conform?
+[✔︎] Is \`tsconfig.build.json\` present, and does it conform?
+[✔︎] Is \`tsup.config.ts\` present, and does it conform?
+[✔︎] Is \`typedoc.json\` present, and does it conform?
+[✔︎] Is \`CHANGELOG.md\` present?
+[✔︎] Is \`CHANGELOG.md\` well-formatted?
+[✔︎] Is \`.editorconfig\` present, and does it conform?
+[✔︎] Is \`.gitattributes\` present, and does it conform?
+[✔︎] Is \`.gitignore\` present, and does it conform?
 
 Results:       40 passed, 0 failed, 0 errored, 40 total
 Elapsed time:  0 ms
@@ -333,38 +333,38 @@ Elapsed time:  0 ms
 repo-1
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ❌
-  - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ❌
-  - \`CHANGELOG.md\` does not exist in this project.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+[✘] Is the classic Yarn config file (\`.yarnrc\`) absent?
+    - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
+[✘] Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+[✘] Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+[✘] Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+[✘] Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+[✘] Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+[✘] Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+[✘] Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+[✘] Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+[✘] Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+[✘] Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+[✘] Is \`CHANGELOG.md\` present?
+    - \`CHANGELOG.md\` does not exist in this project.
+[✘] Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+[✘] Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+[✘] Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
 Results:       0 passed, 15 failed, 0 errored, 15 total
 Elapsed time:  0 ms
@@ -373,38 +373,38 @@ Elapsed time:  0 ms
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ❌
-  - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ❌
-  - \`CHANGELOG.md\` does not exist in this project.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+[✘] Is the classic Yarn config file (\`.yarnrc\`) absent?
+    - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
+[✘] Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+[✘] Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+[✘] Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+[✘] Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+[✘] Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+[✘] Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+[✘] Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+[✘] Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+[✘] Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+[✘] Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+[✘] Is \`CHANGELOG.md\` present?
+    - \`CHANGELOG.md\` does not exist in this project.
+[✘] Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+[✘] Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+[✘] Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
 Results:       0 passed, 15 failed, 0 errored, 15 total
 Elapsed time:  0 ms
@@ -455,38 +455,38 @@ Elapsed time:  0 ms
 repo-1
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ✅
-- Is \`CHANGELOG.md\` well-formatted? ⚠️
-  - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-1/package.json'.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+[✔︎] Is the classic Yarn config file (\`.yarnrc\`) absent?
+[✘] Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+[✘] Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+[✘] Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+[✘] Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+[✘] Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+[✘] Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+[✘] Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+[✘] Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+[✘] Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+[✘] Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+[✔︎] Is \`CHANGELOG.md\` present?
+[?] Is \`CHANGELOG.md\` well-formatted?
+    - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-1/package.json'.
+[✘] Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+[✘] Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+[✘] Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
 Results:       2 passed, 13 failed, 1 errored, 16 total
 Elapsed time:  0 ms
@@ -495,38 +495,38 @@ Elapsed time:  0 ms
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ✅
-- Is \`CHANGELOG.md\` well-formatted? ⚠️
-  - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-2/package.json'.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+[✔︎] Is the classic Yarn config file (\`.yarnrc\`) absent?
+[✘] Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+[✘] Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+[✘] Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+[✘] Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+[✘] Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+[✘] Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+[✘] Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+[✘] Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+[✘] Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+[✘] Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+[✔︎] Is \`CHANGELOG.md\` present?
+[?] Is \`CHANGELOG.md\` well-formatted?
+    - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-2/package.json'.
+[✘] Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+[✘] Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+[✘] Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
 Results:       2 passed, 13 failed, 1 errored, 16 total
 Elapsed time:  0 ms
@@ -581,37 +581,37 @@ Cloning repository MetaMask/repo-2, please wait...
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ❌
-  - \`CHANGELOG.md\` does not exist in this project.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+[✔︎] Is the classic Yarn config file (\`.yarnrc\`) absent?
+[✘] Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+[✘] Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+[✘] Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+[✘] Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+[✘] Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+[✘] Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+[✘] Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+[✘] Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+[✘] Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+[✘] Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+[✘] Is \`CHANGELOG.md\` present?
+    - \`CHANGELOG.md\` does not exist in this project.
+[✘] Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+[✘] Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+[✘] Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
 Results:       1 passed, 14 failed, 0 errored, 15 total
 Elapsed time:  0 ms
@@ -780,46 +780,46 @@ Elapsed time:  0 ms
 repo-1
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ✅
-- Does the \`packageManager\` field in \`package.json\` conform? ✅
-- Does the \`engines.node\` field in \`package.json\` conform? ✅
-- Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the test-related \`scripts\` in \`package.json\` conform? ✅
-- Do the typescript-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typescript-related \`scripts\` in \`package.json\` conform? ✅
-- Does the \`exports\` field in \`package.json\` conform? ✅
-- Does the \`main\` field in \`package.json\` conform? ✅
-- Does the \`module\` field in \`package.json\` conform? ✅
-- Does the \`types\` field in \`package.json\` conform? ✅
-- Does the \`files\` field in \`package.json\` conform? ✅
-- Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
-- Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
-- Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
-- Do the lavamoat-related \`devDependencies\` in \`package.json\` conform? ✅
-- Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`? ✅
-- Is \`README.md\` present? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does the README conform by recommending node install from nodejs.org? ✅
-- Are all of the files for Yarn Modern present, and do they conform? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does allow scripts conforms to yarn? ✅
-- Is the allow-scripts Yarn plugin installed? ✅
-- Does the \`src/\` directory exist? ✅
-- Is \`.nvmrc\` present, and does it conform? ✅
-- Is \`jest.config.js\` present, and does it conform? ✅
-- Is \`tsconfig.json\` present, and does it conform? ✅
-- Is \`tsconfig.build.json\` present, and does it conform? ✅
-- Is \`tsup.config.ts\` present, and does it conform? ✅
-- Is \`typedoc.json\` present, and does it conform? ✅
-- Is \`CHANGELOG.md\` present? ✅
-- Is \`CHANGELOG.md\` well-formatted? ✅
-- Is \`.editorconfig\` present, and does it conform? ✅
-- Is \`.gitattributes\` present, and does it conform? ✅
-- Is \`.gitignore\` present, and does it conform? ✅
+[✔︎] Is the classic Yarn config file (\`.yarnrc\`) absent?
+[✔︎] Does the package have a well-formed manifest (\`package.json\`)?
+[✔︎] Does the \`packageManager\` field in \`package.json\` conform?
+[✔︎] Does the \`engines.node\` field in \`package.json\` conform?
+[✔︎] Do the lint-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the jest-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the test-related \`scripts\` in \`package.json\` conform?
+[✔︎] Do the typescript-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the typescript-related \`scripts\` in \`package.json\` conform?
+[✔︎] Does the \`exports\` field in \`package.json\` conform?
+[✔︎] Does the \`main\` field in \`package.json\` conform?
+[✔︎] Does the \`module\` field in \`package.json\` conform?
+[✔︎] Does the \`types\` field in \`package.json\` conform?
+[✔︎] Does the \`files\` field in \`package.json\` conform?
+[✔︎] Does LavaMoat allow scripts for \`tsup>esbuild\`?
+[✔︎] Do the typedoc-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the typedoc-related \`scripts\` in \`package.json\` conform?
+[✔︎] Do the changelog-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the changelog-related \`scripts\` in \`package.json\` conform?
+[✔︎] Do the lavamoat-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`?
+[✔︎] Is \`README.md\` present?
+[✔︎] Does the README conform by recommending the correct Yarn version to install?
+[✔︎] Does the README conform by recommending node install from nodejs.org?
+[✔︎] Are all of the files for Yarn Modern present, and do they conform?
+[✔︎] Does the README conform by recommending the correct Yarn version to install?
+[✔︎] Does allow scripts conforms to yarn?
+[✔︎] Is the allow-scripts Yarn plugin installed?
+[✔︎] Does the \`src/\` directory exist?
+[✔︎] Is \`.nvmrc\` present, and does it conform?
+[✔︎] Is \`jest.config.js\` present, and does it conform?
+[✔︎] Is \`tsconfig.json\` present, and does it conform?
+[✔︎] Is \`tsconfig.build.json\` present, and does it conform?
+[✔︎] Is \`tsup.config.ts\` present, and does it conform?
+[✔︎] Is \`typedoc.json\` present, and does it conform?
+[✔︎] Is \`CHANGELOG.md\` present?
+[✔︎] Is \`CHANGELOG.md\` well-formatted?
+[✔︎] Is \`.editorconfig\` present, and does it conform?
+[✔︎] Is \`.gitattributes\` present, and does it conform?
+[✔︎] Is \`.gitignore\` present, and does it conform?
 
 Results:       40 passed, 0 failed, 0 errored, 40 total
 Elapsed time:  0 ms
@@ -828,46 +828,46 @@ Elapsed time:  0 ms
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ✅
-- Does the \`packageManager\` field in \`package.json\` conform? ✅
-- Does the \`engines.node\` field in \`package.json\` conform? ✅
-- Do the lint-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the jest-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the test-related \`scripts\` in \`package.json\` conform? ✅
-- Do the typescript-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typescript-related \`scripts\` in \`package.json\` conform? ✅
-- Does the \`exports\` field in \`package.json\` conform? ✅
-- Does the \`main\` field in \`package.json\` conform? ✅
-- Does the \`module\` field in \`package.json\` conform? ✅
-- Does the \`types\` field in \`package.json\` conform? ✅
-- Does the \`files\` field in \`package.json\` conform? ✅
-- Does LavaMoat allow scripts for \`tsup>esbuild\`? ✅
-- Do the typedoc-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the typedoc-related \`scripts\` in \`package.json\` conform? ✅
-- Do the changelog-related \`devDependencies\` in \`package.json\` conform? ✅
-- Do the changelog-related \`scripts\` in \`package.json\` conform? ✅
-- Do the lavamoat-related \`devDependencies\` in \`package.json\` conform? ✅
-- Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`? ✅
-- Is \`README.md\` present? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does the README conform by recommending node install from nodejs.org? ✅
-- Are all of the files for Yarn Modern present, and do they conform? ✅
-- Does the README conform by recommending the correct Yarn version to install? ✅
-- Does allow scripts conforms to yarn? ✅
-- Is the allow-scripts Yarn plugin installed? ✅
-- Does the \`src/\` directory exist? ✅
-- Is \`.nvmrc\` present, and does it conform? ✅
-- Is \`jest.config.js\` present, and does it conform? ✅
-- Is \`tsconfig.json\` present, and does it conform? ✅
-- Is \`tsconfig.build.json\` present, and does it conform? ✅
-- Is \`tsup.config.ts\` present, and does it conform? ✅
-- Is \`typedoc.json\` present, and does it conform? ✅
-- Is \`CHANGELOG.md\` present? ✅
-- Is \`CHANGELOG.md\` well-formatted? ✅
-- Is \`.editorconfig\` present, and does it conform? ✅
-- Is \`.gitattributes\` present, and does it conform? ✅
-- Is \`.gitignore\` present, and does it conform? ✅
+[✔︎] Is the classic Yarn config file (\`.yarnrc\`) absent?
+[✔︎] Does the package have a well-formed manifest (\`package.json\`)?
+[✔︎] Does the \`packageManager\` field in \`package.json\` conform?
+[✔︎] Does the \`engines.node\` field in \`package.json\` conform?
+[✔︎] Do the lint-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the jest-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the test-related \`scripts\` in \`package.json\` conform?
+[✔︎] Do the typescript-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the typescript-related \`scripts\` in \`package.json\` conform?
+[✔︎] Does the \`exports\` field in \`package.json\` conform?
+[✔︎] Does the \`main\` field in \`package.json\` conform?
+[✔︎] Does the \`module\` field in \`package.json\` conform?
+[✔︎] Does the \`types\` field in \`package.json\` conform?
+[✔︎] Does the \`files\` field in \`package.json\` conform?
+[✔︎] Does LavaMoat allow scripts for \`tsup>esbuild\`?
+[✔︎] Do the typedoc-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the typedoc-related \`scripts\` in \`package.json\` conform?
+[✔︎] Do the changelog-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Do the changelog-related \`scripts\` in \`package.json\` conform?
+[✔︎] Do the lavamoat-related \`devDependencies\` in \`package.json\` conform?
+[✔︎] Are postinstall scripts disabled for \`@lavamoat/preinstall-always-fail\`?
+[✔︎] Is \`README.md\` present?
+[✔︎] Does the README conform by recommending the correct Yarn version to install?
+[✔︎] Does the README conform by recommending node install from nodejs.org?
+[✔︎] Are all of the files for Yarn Modern present, and do they conform?
+[✔︎] Does the README conform by recommending the correct Yarn version to install?
+[✔︎] Does allow scripts conforms to yarn?
+[✔︎] Is the allow-scripts Yarn plugin installed?
+[✔︎] Does the \`src/\` directory exist?
+[✔︎] Is \`.nvmrc\` present, and does it conform?
+[✔︎] Is \`jest.config.js\` present, and does it conform?
+[✔︎] Is \`tsconfig.json\` present, and does it conform?
+[✔︎] Is \`tsconfig.build.json\` present, and does it conform?
+[✔︎] Is \`tsup.config.ts\` present, and does it conform?
+[✔︎] Is \`typedoc.json\` present, and does it conform?
+[✔︎] Is \`CHANGELOG.md\` present?
+[✔︎] Is \`CHANGELOG.md\` well-formatted?
+[✔︎] Is \`.editorconfig\` present, and does it conform?
+[✔︎] Is \`.gitattributes\` present, and does it conform?
+[✔︎] Is \`.gitignore\` present, and does it conform?
 
 Results:       40 passed, 0 failed, 0 errored, 40 total
 Elapsed time:  0 ms
@@ -915,38 +915,38 @@ Elapsed time:  0 ms
 repo-1
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ❌
-  - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ❌
-  - \`CHANGELOG.md\` does not exist in this project.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+[✘] Is the classic Yarn config file (\`.yarnrc\`) absent?
+    - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
+[✘] Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+[✘] Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+[✘] Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+[✘] Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+[✘] Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+[✘] Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+[✘] Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+[✘] Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+[✘] Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+[✘] Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+[✘] Is \`CHANGELOG.md\` present?
+    - \`CHANGELOG.md\` does not exist in this project.
+[✘] Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+[✘] Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+[✘] Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
 Results:       0 passed, 15 failed, 0 errored, 15 total
 Elapsed time:  0 ms
@@ -955,38 +955,38 @@ Elapsed time:  0 ms
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ❌
-  - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ❌
-  - \`CHANGELOG.md\` does not exist in this project.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+[✘] Is the classic Yarn config file (\`.yarnrc\`) absent?
+    - The config file for Yarn Classic, \`.yarnrc\`, is present. Please upgrade this project to Yarn Modern.
+[✘] Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+[✘] Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+[✘] Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+[✘] Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+[✘] Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+[✘] Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+[✘] Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+[✘] Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+[✘] Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+[✘] Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+[✘] Is \`CHANGELOG.md\` present?
+    - \`CHANGELOG.md\` does not exist in this project.
+[✘] Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+[✘] Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+[✘] Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
 Results:       0 passed, 15 failed, 0 errored, 15 total
 Elapsed time:  0 ms
@@ -1037,38 +1037,38 @@ Elapsed time:  0 ms
 repo-1
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ✅
-- Is \`CHANGELOG.md\` well-formatted? ⚠️
-  - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-1/package.json'.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+[✔︎] Is the classic Yarn config file (\`.yarnrc\`) absent?
+[✘] Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+[✘] Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+[✘] Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+[✘] Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+[✘] Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+[✘] Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+[✘] Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+[✘] Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+[✘] Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+[✘] Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+[✔︎] Is \`CHANGELOG.md\` present?
+[?] Is \`CHANGELOG.md\` well-formatted?
+    - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-1/package.json'.
+[✘] Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+[✘] Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+[✘] Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
 Results:       2 passed, 13 failed, 1 errored, 16 total
 Elapsed time:  0 ms
@@ -1077,38 +1077,38 @@ Elapsed time:  0 ms
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ✅
-- Is \`CHANGELOG.md\` well-formatted? ⚠️
-  - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-2/package.json'.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+[✔︎] Is the classic Yarn config file (\`.yarnrc\`) absent?
+[✘] Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+[✘] Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+[✘] Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+[✘] Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+[✘] Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+[✘] Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+[✘] Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+[✘] Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+[✘] Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+[✘] Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+[✔︎] Is \`CHANGELOG.md\` present?
+[?] Is \`CHANGELOG.md\` well-formatted?
+    - ERROR: Encountered an error validating the changelog: Could not read JSON file '${sandboxDirectoryPath}/repositories/repo-2/package.json'.
+[✘] Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+[✘] Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+[✘] Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
 Results:       2 passed, 13 failed, 1 errored, 16 total
 Elapsed time:  0 ms
@@ -1162,37 +1162,37 @@ Elapsed time:  0 ms
 repo-2
 ------
 
-- Is the classic Yarn config file (\`.yarnrc\`) absent? ✅
-- Does the package have a well-formed manifest (\`package.json\`)? ❌
-  - \`package.json\` does not exist in this project.
-- Is \`README.md\` present? ❌
-  - \`README.md\` does not exist in this project.
-- Are all of the files for Yarn Modern present, and do they conform? ❌
-  - \`.yarnrc.yml\` does not exist in this project.
-  - \`.yarn/releases/\` does not exist in this project.
-  - \`.yarn/plugins/\` does not exist in this project.
-- Does the \`src/\` directory exist? ❌
-  - \`src/\` does not exist in this project.
-- Is \`.nvmrc\` present, and does it conform? ❌
-  - \`.nvmrc\` does not exist in this project.
-- Is \`jest.config.js\` present, and does it conform? ❌
-  - \`jest.config.js\` does not exist in this project.
-- Is \`tsconfig.json\` present, and does it conform? ❌
-  - \`tsconfig.json\` does not exist in this project.
-- Is \`tsconfig.build.json\` present, and does it conform? ❌
-  - \`tsconfig.build.json\` does not exist in this project.
-- Is \`tsup.config.ts\` present, and does it conform? ❌
-  - \`tsup.config.ts\` does not exist in this project.
-- Is \`typedoc.json\` present, and does it conform? ❌
-  - \`typedoc.json\` does not exist in this project.
-- Is \`CHANGELOG.md\` present? ❌
-  - \`CHANGELOG.md\` does not exist in this project.
-- Is \`.editorconfig\` present, and does it conform? ❌
-  - \`.editorconfig\` does not exist in this project.
-- Is \`.gitattributes\` present, and does it conform? ❌
-  - \`.gitattributes\` does not exist in this project.
-- Is \`.gitignore\` present, and does it conform? ❌
-  - \`.gitignore\` does not exist in this project.
+[✔︎] Is the classic Yarn config file (\`.yarnrc\`) absent?
+[✘] Does the package have a well-formed manifest (\`package.json\`)?
+    - \`package.json\` does not exist in this project.
+[✘] Is \`README.md\` present?
+    - \`README.md\` does not exist in this project.
+[✘] Are all of the files for Yarn Modern present, and do they conform?
+    - \`.yarnrc.yml\` does not exist in this project.
+    - \`.yarn/releases/\` does not exist in this project.
+    - \`.yarn/plugins/\` does not exist in this project.
+[✘] Does the \`src/\` directory exist?
+    - \`src/\` does not exist in this project.
+[✘] Is \`.nvmrc\` present, and does it conform?
+    - \`.nvmrc\` does not exist in this project.
+[✘] Is \`jest.config.js\` present, and does it conform?
+    - \`jest.config.js\` does not exist in this project.
+[✘] Is \`tsconfig.json\` present, and does it conform?
+    - \`tsconfig.json\` does not exist in this project.
+[✘] Is \`tsconfig.build.json\` present, and does it conform?
+    - \`tsconfig.build.json\` does not exist in this project.
+[✘] Is \`tsup.config.ts\` present, and does it conform?
+    - \`tsup.config.ts\` does not exist in this project.
+[✘] Is \`typedoc.json\` present, and does it conform?
+    - \`typedoc.json\` does not exist in this project.
+[✘] Is \`CHANGELOG.md\` present?
+    - \`CHANGELOG.md\` does not exist in this project.
+[✘] Is \`.editorconfig\` present, and does it conform?
+    - \`.editorconfig\` does not exist in this project.
+[✘] Is \`.gitattributes\` present, and does it conform?
+    - \`.gitattributes\` does not exist in this project.
+[✘] Is \`.gitignore\` present, and does it conform?
+    - \`.gitignore\` does not exist in this project.
 
 Results:       1 passed, 14 failed, 0 errored, 15 total
 Elapsed time:  0 ms

--- a/src/report-project-lint-result.test.ts
+++ b/src/report-project-lint-result.test.ts
@@ -71,13 +71,13 @@ describe('reportProjectLintResult', () => {
 some-project
 ------------
 
-- Description for rule 1 ✅
-- Description for rule 2 ❌
-  - Failure 1
-  - Failure 2
-- Description for rule 3 ✅
-- Description for rule 4 ⚠️
-  - ERROR: oops
+[✔︎] Description for rule 1
+[✘] Description for rule 2
+    - Failure 1
+    - Failure 2
+[✔︎] Description for rule 3
+[?] Description for rule 4
+    - ERROR: oops
 
 Results:       2 passed, 1 failed, 1 errored, 4 total
 Elapsed time:  30 ms

--- a/src/report-project-lint-result.ts
+++ b/src/report-project-lint-result.ts
@@ -84,17 +84,30 @@ export function reportProjectLintResult({
 /**
  * Determines an appropriate icon for a rule execution result.
  *
+ * Note that we include `[` and `]` around the icon in the output, but we set
+ * them to use the same foreground color as the background, so that they're
+ * hidden when using colors but visible when not. This way we can reuse this
+ * output for Slack messages.
+ *
  * @param ruleExecutionStatus - The status of executing a rule.
  * @returns The icon as a string.
  */
 function determineIconFor(ruleExecutionStatus: RuleExecutionStatus) {
   if (ruleExecutionStatus === RuleExecutionStatus.Failed) {
-    return '❌';
+    return chalk.red.bgRed('[') + chalk.white.bgRed('✘') + chalk.red.bgRed(']');
   }
   if (ruleExecutionStatus === RuleExecutionStatus.Errored) {
-    return '⚠️';
+    return (
+      chalk.yellow.bgYellow('[') +
+      chalk.black.bgYellow('?') +
+      chalk.yellow.bgYellow(']')
+    );
   }
-  return '✅';
+  return (
+    chalk.green.bgGreen('[') +
+    chalk.black.bgGreen('✔︎') +
+    chalk.green.bgGreen(']')
+  );
 }
 
 /**
@@ -119,9 +132,9 @@ function reportRuleExecutionResultNodes({
 
   for (const ruleExecutionResultNode of ruleExecutionResultNodes) {
     outputLogger.logToStdout(
-      `- ${ruleExecutionResultNode.result.ruleDescription} ${determineIconFor(
-        ruleExecutionResultNode.result.status,
-      )}`,
+      `${determineIconFor(ruleExecutionResultNode.result.status)} ${
+        ruleExecutionResultNode.result.ruleDescription
+      }`,
     );
 
     if (ruleExecutionResultNode.result.status === RuleExecutionStatus.Passed) {
@@ -132,7 +145,7 @@ function reportRuleExecutionResultNodes({
       totalFailed += 1;
 
       for (const failure of ruleExecutionResultNode.result.failures) {
-        outputLogger.logToStdout(indent(`- ${chalk.red(failure.message)}`, 1));
+        outputLogger.logToStdout(indent(`- ${chalk.red(failure.message)}`, 2));
       }
     } else if (
       ruleExecutionResultNode.result.status === RuleExecutionStatus.Errored
@@ -144,7 +157,7 @@ function reportRuleExecutionResultNodes({
           `- ${chalk.yellow(
             `ERROR: ${getErrorMessage(ruleExecutionResultNode.result.error)}`,
           )}`,
-          1,
+          2,
         ),
       );
     }


### PR DESCRIPTION
This commit simply aligns the output so that all of the icons that mark whether a rule passed, failed, or errored are on the left hand side. This makes the output prettier and makes it easier to tell what the status of a rule is. This commit also eschews emoji (which pop out too much) for other kinds of characters.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## References

Tangential followup to #89.

Blocked by #93.

## Screenshots

### Before

<img width="1728" alt="Screenshot 2024-06-05 at 1 53 38 PM" src="https://github.com/MetaMask/module-lint/assets/7371/635e7d9e-df0f-4680-b024-c52be4aef00b">

### After

<img width="1727" alt="Screenshot 2024-06-05 at 2 13 04 PM" src="https://github.com/MetaMask/module-lint/assets/7371/e234693c-ad19-4bbf-be6c-f335d85f24d7">
