### PR TITLE
Use module/moduleResolution of 'nodenext'

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/utils": "^8.4.0",
+    "@metamask/superstruct": "^3.0.0",
+    "@metamask/utils": "^8.5.0",
     "chalk": "^4.1.2",
     "dependency-graph": "^0.11.0",
     "execa": "^5.1.1",
     "lodash": "^4.17.21",
-    "superstruct": "^1.0.3",
     "yaml": "^2.4.1",
     "yargs": "^17.7.2"
   },

--- a/src/misc-utils.test.ts
+++ b/src/misc-utils.test.ts
@@ -1,7 +1,7 @@
+import * as superstruct from '@metamask/superstruct';
 import { writeFile } from '@metamask/utils/node';
 import fs from 'fs';
 import path from 'path';
-import * as superstruct from 'superstruct';
 
 import {
   assertJsonMatchesStruct,
@@ -16,9 +16,9 @@ import {
 import { withinSandbox } from '../tests/helpers';
 
 // Clone the superstruct module so we can spy on its exports
-jest.mock('superstruct', () => {
+jest.mock('@metamask/superstruct', () => {
   return {
-    ...jest.requireActual('superstruct'),
+    ...jest.requireActual('@metamask/superstruct'),
     // eslint-disable-next-line @typescript-eslint/naming-convention
     __esModule: true,
   };

--- a/src/misc-utils.ts
+++ b/src/misc-utils.ts
@@ -1,3 +1,5 @@
+import { StructError, assert } from '@metamask/superstruct';
+import type { Struct, ObjectSchema } from '@metamask/superstruct';
 import {
   isErrorWithCode,
   wrapError as originalWrapError,
@@ -5,9 +7,6 @@ import {
 import type { Json } from '@metamask/utils/node';
 import fs from 'fs';
 import path from 'path';
-import { StructError, assert } from 'superstruct';
-import type { Struct } from 'superstruct';
-import type { ObjectSchema } from 'superstruct/dist/utils';
 
 /**
  * Represents a directory entry. Like fs.Dirent, but includes two additional

--- a/src/repository-filesystem.test.ts
+++ b/src/repository-filesystem.test.ts
@@ -1,3 +1,4 @@
+import { integer, object, string } from '@metamask/superstruct';
 import * as utils from '@metamask/utils/node';
 import {
   ensureDirectoryStructureExists,
@@ -6,7 +7,6 @@ import {
 import fs from 'fs';
 import { mock } from 'jest-mock-extended';
 import path from 'path';
-import { integer, object, string } from 'superstruct';
 import { stringify } from 'yaml';
 
 import { RepositoryFilesystem } from './repository-filesystem';

--- a/src/repository-filesystem.ts
+++ b/src/repository-filesystem.ts
@@ -1,9 +1,8 @@
+import type { Struct, ObjectSchema } from '@metamask/superstruct';
 import type { Json } from '@metamask/utils/node';
 import { readFile, readJsonFile } from '@metamask/utils/node';
 import type fs from 'fs';
 import path from 'path';
-import type { Struct } from 'superstruct';
-import type { ObjectSchema } from 'superstruct/dist/utils';
 import { parse as yamlParse } from 'yaml';
 
 import type { DirectoryEntry } from './misc-utils';

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -1,4 +1,4 @@
-import { type, string, record, array, boolean } from 'superstruct';
+import { type, string, record, array, boolean } from '@metamask/superstruct';
 
 /**
  * All of the known rules.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,14 +4,11 @@
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["ES2020"],
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noEmit": true,
     "noErrorTruncation": true,
     "noUncheckedIndexedAccess": true,
-    "paths": {
-      "@metamask/utils/node": ["./node_modules/@metamask/utils/dist/types/node"]
-    },
     "strict": true,
     "target": "es2020"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -996,7 +996,8 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.0.0
     "@metamask/eslint-config-nodejs": ^12.0.0
     "@metamask/eslint-config-typescript": ^12.0.0
-    "@metamask/utils": ^8.4.0
+    "@metamask/superstruct": ^3.0.0
+    "@metamask/utils": ^8.5.0
     "@swc/cli": ^0.1.62
     "@swc/core": ^1.3.66
     "@types/jest": ^28.1.6
@@ -1025,7 +1026,6 @@ __metadata:
     rimraf: ^3.0.2
     stdio-mock: ^1.2.0
     strip-ansi: ^6.0.0
-    superstruct: ^1.0.3
     ts-jest: ^28.0.7
     ts-node: ^10.7.0
     typedoc: ^0.23.15
@@ -1037,20 +1037,27 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/utils@npm:^8.4.0":
-  version: 8.4.0
-  resolution: "@metamask/utils@npm:8.4.0"
+"@metamask/superstruct@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/superstruct@npm:3.0.0"
+  checksum: 667f8f2947186972516bb72b4ba215eaeede257c8beb0450583dd4c8b00c28729ff938267ca8804a3a351277fd627b8607cafeb71eb7045a2b6930639bb6a341
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^8.5.0":
+  version: 8.5.0
+  resolution: "@metamask/utils@npm:8.5.0"
   dependencies:
     "@ethereumjs/tx": ^4.2.0
+    "@metamask/superstruct": ^3.0.0
     "@noble/hashes": ^1.3.1
     "@scure/base": ^1.1.3
     "@types/debug": ^4.1.7
     debug: ^4.3.4
     pony-cause: ^2.1.10
     semver: ^7.5.4
-    superstruct: ^1.0.3
     uuid: ^9.0.1
-  checksum: b0397e97bac7192f6189a8625a2dfcb56d3c2cf4dd2cb3d4e012a7e9786f04f59f6917805544bc131a6dacd2c8344e237ae43ad47429bb5eb35c6cf1248440b4
+  checksum: e8eac1c796c3f6b623be3c2736e8682248620f666b180f5c12ce56ee09587d4e28b6811862139a05c7a1bec91415f10ccf0516f3cdf342f88b0189d2a057c24b
   languageName: node
   linkType: hard
 
@@ -6645,13 +6652,6 @@ __metadata:
     "@tokenizer/token": ^0.3.0
     peek-readable: ^5.0.0
   checksum: 2ebe7ad8f2aea611dec6742cf6a42e82764892a362907f7ce493faf334501bf981ce21c828dcc300457e6d460dc9c34d644ededb3b01dcb9e37559203cf1748c
-  languageName: node
-  linkType: hard
-
-"superstruct@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "superstruct@npm:1.0.3"
-  checksum: 761790bb111e6e21ddd608299c252f3be35df543263a7ebbc004e840d01fcf8046794c274bcb351bdf3eae4600f79d317d085cdbb19ca05803a4361840cc9bb1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`@metamask/utils` ships with Node-specific functions, but in order to use them you have to import them a special way. Instead of saying

    import { ... } from '@metamask/utils';

you have to say

    import { ... } from '@metamask/utils/node';

However, this syntax only works if TypeScript is configured to use a `module` and `moduleResolution` option of `nodenext` (or `node16`), because then TypeScript will consult the `exports` field of `@metamask/utils` to know how to resolve `@metamask/utils/node` (which it does not do with the current value for this option).

`module-lint` wasn't using this TypeScript configuration option; it used a hack to manually resolve `@metamask/utils/node` to the right place. This hack will no longer work in newer versions of `@metamask/utils`, and in order to make this work we now have to use the aforementioned TypeScript configuration option.

At the same time, the `superstruct` package will not compile when using this configuration option, so to fix this, we also switch to our fork of `superstruct`, which does work.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
